### PR TITLE
fix for NVMe device which support write cache

### DIFF
--- a/src/sntl_helper.c
+++ b/src/sntl_helper.c
@@ -7622,6 +7622,10 @@ int sntl_Check_Operation_Code_and_Service_Action(tDevice *device, ScsiIoCtx *scs
                 break;
             }
         }
+	else
+	{
+		commandSupported = false;
+	}
     }
     break;//Write buffer cmd
 #if defined SNTL_EXT


### PR DESCRIPTION
While using seachest on NVMe device which support write caches, openSeachest was segfaulting. This happened because the `commandSupported` was not set to false when processing NVMe devices
which had write cache support.

This issue will occur in NVMe devices which come by default in AWS `m5d.large` instance. Those devices have support for write cache but is disabled by default.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>