### PR TITLE
set_Device_Name leads to a segfault

### DIFF
--- a/src/uscsi_helper.c
+++ b/src/uscsi_helper.c
@@ -122,7 +122,7 @@ static int set_Device_Partition_Info(tDevice* device)
 {
     int ret = SUCCESS;
     int partitionCount = 0;
-    char blockHandle[OS_HANDLE_NAME_MAX_LENGTH] = 0;
+    char blockHandle[OS_HANDLE_NAME_MAX_LENGTH] = {0};
     snprintf(blockHandle, OS_HANDLE_NAME_MAX_LENGTH, "/dev/");
     set_Device_Name(device->os_info.name, &blockHandle[strlen("/dev/")], OS_HANDLE_NAME_MAX_LENGTH - strlen("/dev/"));
     //note: this mess above is to get rid of /rdsk/ in the file handle as that raw disk handle won't be part of the information in the mount tab file.
@@ -181,8 +181,6 @@ int get_Device(const char *filename, tDevice *device)
     device->os_info.osType = OS_SOLARIS;
     device->os_info.minimumAlignment = sizeof(void *);//setting to be compatible with certain aligned memory allocation functions.
 
-    set_Device_Partition_Info(device);
-
     //Adding support for different device discovery options. 
     if (device->dFlags == OPEN_HANDLE_ONLY)
     {
@@ -193,6 +191,7 @@ int get_Device(const char *filename, tDevice *device)
     {
         //set the name
         snprintf(device->os_info.name, OS_HANDLE_NAME_MAX_LENGTH, filename);
+        set_Device_Partition_Info(device);
         //set the friendly name
         set_Device_Name(filename, device->os_info.friendlyName, OS_HANDLE_FRIENDLY_NAME_MAX_LENGTH);
 
@@ -666,7 +665,7 @@ int os_Unmount_File_Systems_On_Device(tDevice *device)
 {
     int ret = SUCCESS;
     int partitionCount = 0;
-    char blockHandle[OS_HANDLE_NAME_MAX_LENGTH] = 0;
+    char blockHandle[OS_HANDLE_NAME_MAX_LENGTH] = {0};
     snprintf(blockHandle, OS_HANDLE_NAME_MAX_LENGTH, "/dev/");
     set_Device_Name(device->os_info.name, &blockHandle[strlen("/dev/")], OS_HANDLE_NAME_MAX_LENGTH - strlen("/dev/"));
     //note: this mess above is to get rid of /rdsk/ in the file handle as that raw disk handle won't be part of the information in the mount tab file.


### PR DESCRIPTION
The initializer changes are not relevant to the problem, but at least with gcc-10 on Omni the compiler does not like them.
```
[27/113] Compiling C object subprojects/opensea-transport/libopensea-transport.a.p/src_uscsi_helper.c.o
FAILED: subprojects/opensea-transport/libopensea-transport.a.p/src_uscsi_helper.c.o
/opt/gcc-10/bin/gcc -Isubprojects/opensea-transport/libopensea-transport.a.p -Isubprojects/opensea-transport -I../subprojects/opensea-transport -I../subprojects/opensea-transport/include -I../subprojects/opensea-transport/include/vendor -I../subprojects/opensea-common/include -fdiagnostics-color=always -Wall -Winvalid-pch -g -D_DEBUG -ffunction-sections -fdata-sections -fPIC -DDISABLE_NVME_PASSTHROUGH -MD -MQ subprojects/opensea-transport/libopensea-transport.a.p/src_uscsi_helper.c.o -MF subprojects/opensea-transport/libopensea-transport.a.p/src_uscsi_helper.c.o.d -o subprojects/opensea-transport/libopensea-transport.a.p/src_uscsi_helper.c.o -c ../subprojects/opensea-transport/src/uscsi_helper.c
../subprojects/opensea-transport/src/uscsi_helper.c: In function 'set_Device_Partition_Info':
../subprojects/opensea-transport/src/uscsi_helper.c:125:51: error: invalid initializer
  125 |     char blockHandle[OS_HANDLE_NAME_MAX_LENGTH] = 0;
      |                                                   ^
../subprojects/opensea-transport/src/uscsi_helper.c: In function 'os_Unmount_File_Systems_On_Device':
../subprojects/opensea-transport/src/uscsi_helper.c:670:51: error: invalid initializer
  670 |     char blockHandle[OS_HANDLE_NAME_MAX_LENGTH] = 0;
      |
```
The primary problem which this PR attempts to address is the call to `set_Device_Partition_Info` before `device->os_info.name` has anything meaningful. I am not sure if this change makes semantic sense to you, but to me it seems like this is more correct. It does not seem to make sense to have `set_Device_Partition_Info(device);` outside of the block where I place it, and `device->os_info.name` needs to have sensible value before `set_Device_Partition_Info` is invoked. With this tweak in my tests so far, things seem to work correctly on illumos.