### PR TITLE
quick: ata_cmds.c: remove redundant judgement on variable "feature"

### DIFF
--- a/src/ata_cmds.c
+++ b/src/ata_cmds.c
@@ -568,7 +568,7 @@ int ata_SMART_Command(tDevice *device, uint8_t feature, uint8_t lbaLo, uint8_t *
         ataCommandOptions.commadProtocol = ATA_PROTOCOL_PIO;
         break;
     case ATA_SMART_WRITE_LOG:
-        if (VERBOSITY_COMMAND_NAMES <= device->deviceVerbosity && feature == ATA_SMART_READ_LOG)
+        if (VERBOSITY_COMMAND_NAMES <= device->deviceVerbosity && feature == ATA_SMART_WRITE_LOG)
         {
             printf("Write Log - Log %02"PRIX8"h\n", lbaLo);
         }


### PR DESCRIPTION
When I read these lines, I found the judgement in these `if` lines are already implemented in the bigger `switch` clause in line 546.
So I think they are just redundent judgements, are they?

Signed-off-by: ThunderEX <thunderex@gmail.com>