### PR TITLE
make: add missing header & removing strange file from project

### DIFF
--- a/Make/VS.2019/opensea-transport/opensea-transport-DLL/opensea-transport-DLL.vcxproj
+++ b/Make/VS.2019/opensea-transport/opensea-transport-DLL/opensea-transport-DLL.vcxproj
@@ -989,9 +989,6 @@
     </ClCompile>
     <ClCompile Include="..\..\..\..\src\win_helper.c" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\..\..\src\cppdeps.pl" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Make/VS.2019/opensea-transport/opensea-transport-DLL/opensea-transport-DLL.vcxproj.filters
+++ b/Make/VS.2019/opensea-transport/opensea-transport-DLL/opensea-transport-DLL.vcxproj.filters
@@ -255,9 +255,4 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\..\..\src\cppdeps.pl">
-      <Filter>Source Files</Filter>
-    </None>
-  </ItemGroup>
 </Project>

--- a/src/csmi_helper.c
+++ b/src/csmi_helper.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stddef.h> // offsetof
 #include <sys/types.h>
 #include <fcntl.h>
 #include <assert.h>


### PR DESCRIPTION
Hi,

This commit includes two minor changes:

1. Add missing include of stddef.h, which I find causing build fail on MSVC 2013,
2. Cheery-pick 6e55d84 which remove a strange file from the project, which was done for MSVC 2017 but not 2019.

Signed-off-by: ThunderEX <thunderex@gmail.com>