### PR TITLE
fix: fix ata log 30h page 09h is never visited when filling drive info

### DIFF
--- a/src/ata_helper.c
+++ b/src/ata_helper.c
@@ -1305,7 +1305,7 @@ int fill_In_ATA_Drive_Info(tDevice *device)
                     {
                         //data is valid, so figure out supported pages
                         uint8_t listLen = logBuffer[8];
-                        for (uint16_t iter = 9; iter < C_CAST(uint16_t, listLen + 8) && iter < UINT16_C(512); ++iter)
+                        for (uint16_t iter = 9; iter < C_CAST(uint16_t, listLen + 9) && iter < UINT16_C(512); ++iter)
                         {
                             switch (logBuffer[iter])
                             {


### PR DESCRIPTION
I find out that with this line, the last page (09h) of log 30h is not visited, thus `zonedDeviceInfo` in line 1329 is never assigned to `true`, furthermore, check in line 1382 is never reachable.