### PR TITLE
quick: fix block handle missing in sg_helper.c

### DIFF
--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -1456,8 +1456,8 @@ eReturnValues map_Block_To_Generic_Handle(const char* handle, char** genericHand
                 struct dirent** classList;
                 int             numberOfItems = scandir(classPath, &classList,
                                                         M_NULLPTR /*not filtering anything. Just go through each item*/, alphasort);
-                eReturnValues   ret           = SUCCESS;
-                for (int iter = 0; iter < numberOfItems && ret == SUCCESS; ++iter)
+                eReturnValues   ret           = UNKNOWN;
+                for (int iter = 0; iter < numberOfItems && ret == UNKNOWN; ++iter)
                 {
                     // now we need to read the link for classPath/d_name into a buffer...then compare it to the one we
                     // read earlier.
@@ -1514,6 +1514,7 @@ eReturnValues map_Block_To_Generic_Handle(const char* handle, char** genericHand
                                                                      (M_STATIC_CAST(uintptr_t, classPtr) -
                                                                       M_STATIC_CAST(uintptr_t, mapLink))) == 0)
                                 {
+                                    ret = SUCCESS;
                                     if (incomingBlock)
                                     {
                                         if (0 != safe_strndup(blockHandle, basehandle, safe_strlen(basehandle)) ||
@@ -1547,7 +1548,7 @@ eReturnValues map_Block_To_Generic_Handle(const char* handle, char** genericHand
                     safe_free_dirent(&classList[classiter]);
                 }
                 safe_free_dirent(M_REINTERPRET_CAST(struct dirent**, &classList));
-                if (ret != SUCCESS)
+                if (ret != UNKNOWN)
                 {
                     return ret;
                 }


### PR DESCRIPTION
During d443a1432f8484236eed50a56fe74b51f80dc872 and 6e204cd28d86be216b6c434c2efe556cc229c937, changes lead to `map_Block_To_Generic_Handle` won't return SUCCESS even if a matched block handle is found. As a result, device scan with `-s -F sgtosd` won't return sd handle any more.

I tried to fix based on my understanding and now it works. Please take a careful review in case I introduced something wrong.