### PR TITLE
quick: add smart version into ataSMARTLog struct

### DIFF
--- a/include/ata_helper.h
+++ b/include/ata_helper.h
@@ -1664,6 +1664,7 @@ extern "C"
 #define ATA_SMART_LOG_MAX_ATTRIBUTES (256)
     typedef struct s_ataSMARTLog
     {
+        uint16_t smartVersion;
         ataSMARTValue attributes[ATA_SMART_LOG_MAX_ATTRIBUTES]; // attribute numbers 1 - 255 are valid (check valid bit
                                                                 // to make sure it's a used attribute)
     } ataSMARTLog;


### PR DESCRIPTION
This is basis of another PR in opensea-operation.

SMART version is first 2 bytes in SMART attribute output, which distinguish version of SMART attribute structure.
It was defined in struct `smartFeatureInfo` in https://github.com/Seagate/opensea-operations/blob/2efda60b5a94784d013ce64119f634e102515fab/include/smart.h#L481. But it's now added into this `ataSMARTLog` struct, with which we can easily pass this value from `get_SMART_Attributes` to `print_Hybrid_ATA_Attributes` and `print_Analyzed_ATA_Attributes` without much change to interface.