### PR TITLE
bug: fix firmware download with pio cmd but dma protocol

### DIFF
--- a/src/ata_cmds.c
+++ b/src/ata_cmds.c
@@ -1147,7 +1147,7 @@ eReturnValues ata_Download_Microcode(tDevice*                   device,
         else
         {
             ataCommandOptions =
-                create_ata_dma_out_cmd(device, ATA_DOWNLOAD_MICROCODE_CMD, false, M_Byte0(blockCount), pData, dataLen);
+                create_ata_pio_out_cmd(device, ATA_DOWNLOAD_MICROCODE_CMD, false, M_Byte0(blockCount), pData, dataLen);
         }
         ataCommandOptions.tfr.ErrorFeature = C_CAST(uint8_t, subCommand);
         ataCommandOptions.tfr.LbaLow       = M_Byte1(blockCount);


### PR DESCRIPTION
Firmware download is broken since https://github.com/Seagate/opensea-transport/commit/3a29d57c05bd1ad3f0c1eb16f39c77a61ce8c3ac#diff-3b407c1f15ee4f15f890a9077b35f5ae5799a6b35e541ea1b51a682f4e80d7e6

ATA_DOWNLOAD_MICROCODE_CMD is PIO command, while function of dma is called.

I find v25.05.01 can't download firmware on many servers due to the bug because modern Seagate drives only support PIO method download. Could we have a v.25.05.02 fix?