### PR TITLE
Feature/changing locks

### DIFF
--- a/include/common_public.h
+++ b/include/common_public.h
@@ -1320,7 +1320,8 @@ extern "C"
         uint8_t minimumAlignment; // This is a power of 2 value representing the byte alignment required. 0 - no
                                   // requirement, 1 - single byte alignment, 2 - word, 4 - dword, 8 - qword, 16 - 128bit
                                   // aligned
-        uint8_t padd0[3];
+        uint16_t lockCount; // Tracks lock/unlock requests.
+        uint8_t padd0;
 #if defined(UEFI_C_SOURCE)
         EFI_HANDLE   fd;
         EFI_DEV_PATH devicePath; // This type being used is a union of all the different possible device paths. - This

--- a/src/aix_helper.c
+++ b/src/aix_helper.c
@@ -3373,23 +3373,31 @@ eReturnValues os_Get_Exclusive(M_ATTR_UNUSED tDevice* device)
 eReturnValues os_Lock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    if (!device->os_info.diagnosticModeFlagInUse)
+    if (device->os_info.lockCount == UINT16_C(0))
     {
-        close(device->os_info.fd); // this must be done first or the openx will fail!
-        // try opening with the diagnostic flag.
-        long extensionFlag = SC_DIAGNOSTIC;
-        device->os_info.fd = openx(device->os_info.name, 0, 0, extensionFlag);
-        if (device->os_info.fd >= 0)
+        if (!device->os_info.diagnosticModeFlagInUse)
         {
-            device->os_info.diagnosticModeFlagInUse = true;
-        }
-        else
-        {
-            // reopen original fd without SC_DIAGNOSTIC
-            extensionFlag      = 0;
+            close(device->os_info.fd); // this must be done first or the openx will fail!
+            // try opening with the diagnostic flag.
+            long extensionFlag = SC_DIAGNOSTIC;
             device->os_info.fd = openx(device->os_info.name, 0, 0, extensionFlag);
-            ret                = FAILURE;
+            if (device->os_info.fd >= 0)
+            {
+                device->os_info.diagnosticModeFlagInUse = true;
+            }
+            else
+            {
+                // reopen original fd without SC_DIAGNOSTIC
+                extensionFlag      = 0;
+                device->os_info.fd = openx(device->os_info.name, 0, 0, extensionFlag);
+                ret                = FAILURE;
+            }
         }
+    }
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
+    {
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
     }
     return ret;
 }
@@ -3398,23 +3406,30 @@ eReturnValues os_Lock_Device(tDevice* device)
 eReturnValues os_Unlock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    if (device->os_info.diagnosticModeFlagInUse)
+    if (device->os_info.lockCount == UINT16_C(1))
     {
-        close(device->os_info.fd); // this must be done first or the openx will fail!
-        // try opening without the diagnostic flag.
-        long extensionFlag = 0L;
-        device->os_info.fd = openx(device->os_info.name, 0, 0, extensionFlag);
-        if (device->os_info.fd >= 0)
+        if (device->os_info.diagnosticModeFlagInUse)
         {
-            device->os_info.diagnosticModeFlagInUse = false;
-        }
-        else
-        {
-            // reopen original fd without SC_DIAGNOSTIC
-            extensionFlag      = SC_DIAGNOSTIC;
+            close(device->os_info.fd); // this must be done first or the openx will fail!
+            // try opening without the diagnostic flag.
+            long extensionFlag = 0L;
             device->os_info.fd = openx(device->os_info.name, 0, 0, extensionFlag);
-            ret                = FAILURE;
+            if (device->os_info.fd >= 0)
+            {
+                device->os_info.diagnosticModeFlagInUse = false;
+            }
+            else
+            {
+                // reopen original fd without SC_DIAGNOSTIC
+                extensionFlag      = SC_DIAGNOSTIC;
+                device->os_info.fd = openx(device->os_info.name, 0, 0, extensionFlag);
+                ret                = FAILURE;
+            }
         }
+    }
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
+    {
+        --device->os_info.lockCount;
     }
     return ret;
 }

--- a/src/cam_helper.c
+++ b/src/cam_helper.c
@@ -1606,12 +1606,21 @@ eReturnValues os_Get_Exclusive(M_ATTR_UNUSED tDevice* device)
 eReturnValues os_Lock_Device(M_ATTR_UNUSED tDevice* device)
 {
     // There is nothing to lock since you cannot open a CAM device with O_NONBLOCK
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
+    {
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
+    }
     return SUCCESS;
 }
 
 eReturnValues os_Unlock_Device(M_ATTR_UNUSED tDevice* device)
 {
     // There is nothing to unlock since you cannot open a CAM device with O_NONBLOCK
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
+    {
+        --device->os_info.lockCount;
+    }
     return SUCCESS;
 }
 

--- a/src/netbsd_openbsd_helper.c
+++ b/src/netbsd_openbsd_helper.c
@@ -534,6 +534,11 @@ eReturnValues os_Lock_Device(tDevice* device)
 {
     // flock?
     M_USE_UNUSED(device);
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
+    {
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
+    }
     return OS_COMMAND_NOT_AVAILABLE;
 }
 
@@ -541,6 +546,10 @@ eReturnValues os_Unlock_Device(tDevice* device)
 {
     // flock?
     M_USE_UNUSED(device);
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
+    {
+        --device->os_info.lockCount;
+    }
     return OS_COMMAND_NOT_AVAILABLE;
 }
 

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -3612,13 +3612,21 @@ eReturnValues os_Get_Exclusive(tDevice* device)
 eReturnValues os_Lock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    if (!lock_unlock_handle(device->os_info.fd, true, device->deviceVerbosity))
+    if (device->os_info.lockCount == UINT16_C(0))
     {
-        ret = FAILURE;
+        if (!lock_unlock_handle(device->os_info.fd, true, device->deviceVerbosity))
+        {
+            ret = FAILURE;
+        }
+        if (device->os_info.secondHandleValid && device->os_info.secondHandleOpened)
+        {
+            lock_unlock_handle(device->os_info.fd2, true, device->deviceVerbosity);
+        }
     }
-    if (device->os_info.secondHandleValid && device->os_info.secondHandleOpened)
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
     {
-        lock_unlock_handle(device->os_info.fd2, true, device->deviceVerbosity);
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
     }
     return ret;
 }
@@ -3626,13 +3634,21 @@ eReturnValues os_Lock_Device(tDevice* device)
 eReturnValues os_Unlock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    if (!lock_unlock_handle(device->os_info.fd, false, device->deviceVerbosity))
+    if (device->os_info.lockCount == UINT16_C(1))
     {
-        ret = FAILURE;
+        // only unlock once the number of requests gets back down to here so it will decrement to zero
+        if (!lock_unlock_handle(device->os_info.fd, false, device->deviceVerbosity))
+        {
+            ret = FAILURE;
+        }
+        if (device->os_info.secondHandleValid && device->os_info.secondHandleOpened)
+        {
+            lock_unlock_handle(device->os_info.fd2, false, device->deviceVerbosity);
+        }
     }
-    if (device->os_info.secondHandleValid && device->os_info.secondHandleOpened)
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
     {
-        lock_unlock_handle(device->os_info.fd2, false, device->deviceVerbosity);
+        --device->os_info.lockCount;
     }
     return ret;
 }

--- a/src/uscsi_helper.c
+++ b/src/uscsi_helper.c
@@ -814,27 +814,62 @@ eReturnValues os_Get_Exclusive(M_ATTR_UNUSED tDevice* device)
     return OS_COMMAND_NOT_AVAILABLE;
 }
 
+#define DRIVE_HANDLE_LOCK_RANGE_START  (0)
+#define DRIVE_HANDLE_LOCK_RANGE_LENGTH (0) // 0 means full drive/file
 eReturnValues os_Lock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    // Get flags
-    int flags = fcntl(device->os_info.fd, F_GETFL);
-    // disable O_NONBLOCK
-    flags &= ~O_NONBLOCK;
-    // Set Flags
-    fcntl(device->os_info.fd, F_SETFL, flags);
+    if (device->os_info.lockCount == UINT16_C(1))
+    {
+        struct flock locks;
+        safe_memset(&locks, sizeof(struct flock), 0, sizeof(struct flock));
+        locks.l_type = F_WRLCK;
+        locks.l_whence = SEEK_SET;
+        locks.l_start  = DRIVE_HANDLE_LOCK_RANGE_START;
+        locks.l_len    = DRIVE_HANDLE_LOCK_RANGE_LENGTH;
+        if (fcntl(fd, F_SETLK, &locks) < 0)
+        {
+            if (verboseLevel >= VERBOSITY_COMMAND_NAMES)
+            {
+                printf("Failed to set POSIX F_SETLK %s flags with fcntl\n", lock == true ? "lock" : "unlock");
+                print_Errno_To_Screen(errno);
+            }
+            ret = FAILURE;
+        }
+    }
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
+    {
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
+    }
     return ret;
 }
 
 eReturnValues os_Unlock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    // Get flags
-    int flags = fcntl(device->os_info.fd, F_GETFL);
-    // enable O_NONBLOCK
-    flags |= O_NONBLOCK;
-    // Set Flags
-    fcntl(device->os_info.fd, F_SETFL, flags);
+    if (device->os_info.lockCount == UINT16_C(1))
+    {
+        struct flock locks;
+        safe_memset(&locks, sizeof(struct flock), 0, sizeof(struct flock));
+        locks.l_type = F_UNLCK;
+        locks.l_whence = SEEK_SET;
+        locks.l_start  = DRIVE_HANDLE_LOCK_RANGE_START;
+        locks.l_len    = DRIVE_HANDLE_LOCK_RANGE_LENGTH;
+        if (fcntl(fd, F_SETLK, &locks) < 0)
+        {
+            if (verboseLevel >= VERBOSITY_COMMAND_NAMES)
+            {
+                printf("Failed to set POSIX F_SETLK %s flags with fcntl\n", lock == true ? "lock" : "unlock");
+                print_Errno_To_Screen(errno);
+            }
+            ret = FAILURE;
+        }
+    }
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
+    {
+        --device->os_info.lockCount;
+    }
     return ret;
 }
 

--- a/src/vm_helper.c
+++ b/src/vm_helper.c
@@ -1560,18 +1560,35 @@ eReturnValues os_Get_Exclusive(M_ATTR_UNUSED tDevice* device)
 eReturnValues os_Lock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    if (device->drive_info.drive_type == NVME_DRIVE)
+    if (device->os_info.lockCount == UINT16_C(0))
     {
-        // Not sure what to do
+        if (device->drive_info.drive_type == NVME_DRIVE)
+        {
+            // Not sure what to do
+        }
+        else
+        {
+            struct flock locks;
+            safe_memset(&locks, sizeof(struct flock), 0, sizeof(struct flock));
+            locks.l_type = F_WRLCK;
+            locks.l_whence = SEEK_SET;
+            locks.l_start  = DRIVE_HANDLE_LOCK_RANGE_START;
+            locks.l_len    = DRIVE_HANDLE_LOCK_RANGE_LENGTH;
+            if (fcntl(fd, F_SETLK, &locks) < 0)
+            {
+                if (verboseLevel >= VERBOSITY_COMMAND_NAMES)
+                {
+                    printf("Failed to set POSIX F_SETLK %s flags with fcntl\n", lock == true ? "lock" : "unlock");
+                    print_Errno_To_Screen(errno);
+                }
+                ret = FAILURE;
+            }
+        }
     }
-    else
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
     {
-        // Get flags
-        int flags = fcntl(device->os_info.fd, F_GETFL);
-        // disable O_NONBLOCK
-        flags &= ~O_NONBLOCK;
-        // Set Flags
-        fcntl(device->os_info.fd, F_SETFL, flags);
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
     }
     return ret;
 }
@@ -1579,18 +1596,34 @@ eReturnValues os_Lock_Device(tDevice* device)
 eReturnValues os_Unlock_Device(tDevice* device)
 {
     eReturnValues ret = SUCCESS;
-    if (device->drive_info.drive_type == NVME_DRIVE)
+    if (device->os_info.lockCount == UINT16_C(1))
     {
-        // Not sure what to do
+        if (device->drive_info.drive_type == NVME_DRIVE)
+        {
+            // Not sure what to do
+        }
+        else
+        {
+            struct flock locks;
+            safe_memset(&locks, sizeof(struct flock), 0, sizeof(struct flock));
+            locks.l_type = F_UNLCK;
+            locks.l_whence = SEEK_SET;
+            locks.l_start  = DRIVE_HANDLE_LOCK_RANGE_START;
+            locks.l_len    = DRIVE_HANDLE_LOCK_RANGE_LENGTH;
+            if (fcntl(fd, F_SETLK, &locks) < 0)
+            {
+                if (verboseLevel >= VERBOSITY_COMMAND_NAMES)
+                {
+                    printf("Failed to set POSIX F_SETLK %s flags with fcntl\n", lock == true ? "lock" : "unlock");
+                    print_Errno_To_Screen(errno);
+                }
+                ret = FAILURE;
+            }
+        }
     }
-    else
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
     {
-        // Get flags
-        int flags = fcntl(device->os_info.fd, F_GETFL);
-        // enable O_NONBLOCK
-        flags |= O_NONBLOCK;
-        // Set Flags
-        fcntl(device->os_info.fd, F_SETFL, flags);
+        --device->os_info.lockCount;
     }
     return ret;
 }

--- a/src/win_helper.c
+++ b/src/win_helper.c
@@ -9408,12 +9408,20 @@ eReturnValues os_Get_Exclusive(tDevice* device)
 eReturnValues os_Lock_Device(tDevice* device)
 {
     eReturnValues ret           = SUCCESS;
-    DWORD         returnedBytes = DWORD_C(0);
-    if (MSFT_BOOL_FALSE(DeviceIoControl(device->os_info.fd, FSCTL_LOCK_VOLUME, M_NULLPTR, 0, M_NULLPTR, 0,
-                                        &returnedBytes, M_NULLPTR)))
+    if (device->os_info.lockCount == UINT16_C(0))
     {
-        // This can fail if files are open, it's a system disk, or has a pagefile.
-        ret = FAILURE;
+        DWORD         returnedBytes = DWORD_C(0);
+        if (MSFT_BOOL_FALSE(DeviceIoControl(device->os_info.fd, FSCTL_LOCK_VOLUME, M_NULLPTR, 0, M_NULLPTR, 0,
+                                            &returnedBytes, M_NULLPTR)))
+        {
+            // This can fail if files are open, it's a system disk, or has a pagefile.
+            ret = FAILURE;
+        }
+    }
+    if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
+    {
+        // Always increment this so we know how many times we've been requested to lock
+        ++device->os_info.lockCount;
     }
     return ret;
 }
@@ -9421,11 +9429,18 @@ eReturnValues os_Lock_Device(tDevice* device)
 eReturnValues os_Unlock_Device(tDevice* device)
 {
     eReturnValues ret           = SUCCESS;
-    DWORD         returnedBytes = DWORD_C(0);
-    if (MSFT_BOOL_FALSE(DeviceIoControl(device->os_info.fd, FSCTL_UNLOCK_VOLUME, M_NULLPTR, 0, M_NULLPTR, 0,
-                                        &returnedBytes, M_NULLPTR)))
+    if (device->os_info.lockCount == UINT16_C(1))
     {
-        ret = FAILURE;
+        DWORD         returnedBytes = DWORD_C(0);
+        if (MSFT_BOOL_FALSE(DeviceIoControl(device->os_info.fd, FSCTL_UNLOCK_VOLUME, M_NULLPTR, 0, M_NULLPTR, 0,
+                                            &returnedBytes, M_NULLPTR)))
+        {
+            ret = FAILURE;
+        }
+    }
+    if (ret == SUCCESS && device->os_info.lockCount > 0)
+    {
+        --device->os_info.lockCount;
     }
     return ret;
 }


### PR DESCRIPTION
Changing how locks are requested in Linux due to strange errors we were seeing.

This switched from using both POSIX and BSD locks to only Linux F_OFD_SETLK or POSIX F_SETLK modes. BSD locks are not used and these other locking types are not combined.

I also implemented a counter to track all lock/unlock requests so that these behave as expected when multiple requests are received to keep more consistent behavior.