### PR TITLE
Feature/sgv4 support

### DIFF
--- a/include/common_public.h
+++ b/include/common_public.h
@@ -1536,7 +1536,7 @@ extern "C"
     // forward declare csmi info to avoid including csmi_helper.h
     typedef struct s_csmiDeviceInfo csmiDeviceInfo, *ptrCsmiDeviceInfo;
 
-    static M_INLINE void safe_free_csmi_dev_info(csmiDeviceInfo* M_NULLABLE* M_NULLABLE csmidevinfo)
+    static M_INLINE void safe_free_csmi_dev_info(csmiDeviceInfo * M_NULLABLE * M_NULLABLE csmidevinfo)
     {
         safe_free_core(M_REINTERPRET_CAST(void**, csmidevinfo));
     }
@@ -1544,7 +1544,7 @@ extern "C"
     // forward declare cciss device
     typedef struct s_cissDeviceInfo cissDeviceInfo, *ptrCissDeviceInfo;
 
-    static M_INLINE void safe_free_ciss_dev_info(cissDeviceInfo* M_NULLABLE* M_NULLABLE cissdevinfo)
+    static M_INLINE void safe_free_ciss_dev_info(cissDeviceInfo * M_NULLABLE * M_NULLABLE cissdevinfo)
     {
         safe_free_core(M_REINTERPRET_CAST(void**, cissdevinfo));
     }
@@ -1581,6 +1581,15 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
 #define OS_HANDLE_NAME_MAX_LENGTH          256
 #define OS_HANDLE_FRIENDLY_NAME_MAX_LENGTH 24
 #define OS_SECOND_HANDLE_NAME_LENGTH       30
+#if defined(__linux__) && !defined(VMK_CROSS_COMP)
+    typedef enum osFDTypeEnum
+    {
+        FD_TYPE_NONE,
+        FD_TYPE_BSG,
+        FD_TYPE_SG,
+        FD_TYPE_SD,
+    } osFDType;
+#endif
     // \struct typedef struct s_OSDriveInfo
     typedef struct s_OSDriveInfo
     {
@@ -1633,7 +1642,8 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     int                 fd;
     struct nvme_handle* nvmeFd;
 #    else
-    int fd; // primary handle
+    int      fd; // primary handle
+    osFDType primaryFDType;
 #    endif
     bool scsiAddressValid; // will be true if the SCSI address is a valid address
     struct
@@ -1657,7 +1667,8 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     int                 fd2;
     struct nvme_handle* nvmeFd2;
 #    else
-    int fd2; // secondary handle. Ex: fd = sg handle opened, fd2 = sd handle opened.
+    int      fd2; // secondary handle. Ex: fd = sg handle opened, fd2 = sd handle opened.
+    osFDType secondaryFDType;
 #    endif
     struct
     {
@@ -2677,7 +2688,7 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int        flags,
                                                                     eVerbosityLevels    scanVerbosity,
                                                                     uint32_t* M_NONNULL numberOfDevices,
-                                                                    scanDriveInfo* M_NONNULL* M_NULLABLE deviceList);
+                                                                    scanDriveInfo * M_NONNULL * M_NULLABLE deviceList);
 
     //-----------------------------------------------------------------------------
     //

--- a/include/common_public.h
+++ b/include/common_public.h
@@ -1581,15 +1581,6 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
 #define OS_HANDLE_NAME_MAX_LENGTH          256
 #define OS_HANDLE_FRIENDLY_NAME_MAX_LENGTH 24
 #define OS_SECOND_HANDLE_NAME_LENGTH       30
-#if defined(__linux__) && !defined(VMK_CROSS_COMP)
-    typedef enum osFDTypeEnum
-    {
-        FD_TYPE_NONE,
-        FD_TYPE_BSG,
-        FD_TYPE_SG,
-        FD_TYPE_SD,
-    } osFDType;
-#endif
     // \struct typedef struct s_OSDriveInfo
     typedef struct s_OSDriveInfo
     {
@@ -1642,8 +1633,7 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     int                 fd;
     struct nvme_handle* nvmeFd;
 #    else
-    int      fd; // primary handle
-    osFDType primaryFDType;
+    int fd; // primary handle
 #    endif
     bool scsiAddressValid; // will be true if the SCSI address is a valid address
     struct
@@ -1667,8 +1657,7 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     int                 fd2;
     struct nvme_handle* nvmeFd2;
 #    else
-    int      fd2; // secondary handle. Ex: fd = sg handle opened, fd2 = sd handle opened.
-    osFDType secondaryFDType;
+    int fd2; // secondary handle. Ex: fd = sg handle opened, fd2 = sd handle opened.
 #    endif
     struct
     {

--- a/include/common_public.h
+++ b/include/common_public.h
@@ -1581,6 +1581,7 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
 #define OS_HANDLE_NAME_MAX_LENGTH          256
 #define OS_HANDLE_FRIENDLY_NAME_MAX_LENGTH 24
 #define OS_SECOND_HANDLE_NAME_LENGTH       30
+#define OS_THIRD_HANDLE_NAME_LENGTH        30
     // \struct typedef struct s_OSDriveInfo
     typedef struct s_OSDriveInfo
     {
@@ -1646,7 +1647,11 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     bool secondHandleValid; // must be true for remaining fields to be used.
     char secondName[OS_SECOND_HANDLE_NAME_LENGTH];
     char secondFriendlyName[OS_SECOND_HANDLE_NAME_LENGTH];
-    bool secondHandleOpened;
+#    if !defined(VMK_CROSS_COMP)
+    bool thirdHandleValid; // must be true for remaining fields to be used.
+    char thirdName[OS_THIRD_HANDLE_NAME_LENGTH];
+    char thirdFriendlyName[OS_THIRD_HANDLE_NAME_LENGTH];
+#    endif
 #    if defined(VMK_CROSS_COMP)
     /**
      * In VMWare we discover or send IOCTL to NVMe throught NDDK.
@@ -1657,7 +1662,10 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     int                 fd2;
     struct nvme_handle* nvmeFd2;
 #    else
-    int fd2; // secondary handle. Ex: fd = sg handle opened, fd2 = sd handle opened.
+    bool fd2Opened; // Ex: fd = sg/bsg handle opened, fd2 = sd handle opened.
+    int  fd2;       // second handle. Ex: fd = sg/bsg handle opened, fd2 = sd handle opened.
+    bool fd3Opened; // Ex: fd = bsg handle opened, fd3 = sg handle opened.
+    int  fd3;       // third handle. Ex: fd = bsg handle opened, fd3 = sg handle opened.
 #    endif
     struct
     {
@@ -1773,7 +1781,6 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     bool     secondHandleValid; // must be true for remaining fields to be used.
     char     secondName[OS_SECOND_HANDLE_NAME_LENGTH];
     char     secondFriendlyName[OS_SECOND_HANDLE_NAME_LENGTH];
-    bool     secondHandleOpened;
     uint8_t  otherPadd[50];
 #elif defined(__NetBSD__) || defined(__OpenBSD__)
     int                 fd;
@@ -2007,6 +2014,36 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
                 M_IGNORE_SAFE_ERRNO_CALL(safe_strncpy(device->os_info.secondFriendlyName,
                                                       sizeof(device->os_info.secondFriendlyName), friendlyName,
                                                       OS_SECOND_HANDLE_NAME_LENGTH),
+                                         "This should always fit within this buffer.");
+            }
+#else
+        M_USE_UNUSED(friendlyName);
+#endif
+            // TODO: Make second handles available for all systems since this can come in handy  and make everything
+            // easier to manage.
+        }
+    }
+
+    M_PARAM_RW(1)
+    M_PARAM_RO(2)
+    M_PARAM_RO(3)
+    M_NULL_TERM_STRING(2)
+    M_NULL_TERM_STRING(3)
+    static M_INLINE void set_Third_Device_Name_In_tDevice(tDevice* M_NONNULL     device,
+                                                          const char* M_NONNULL  name,
+                                                          const char* M_NULLABLE friendlyName)
+    {
+        if (device != M_NULLPTR && name != M_NULLPTR)
+        {
+#if defined(__linux__) && !defined(VMK_CROSS_COMP)
+            M_IGNORE_SAFE_ERRNO_CALL(safe_strncpy(device->os_info.thirdName, sizeof(device->os_info.thirdName), name,
+                                                  OS_THIRD_HANDLE_NAME_LENGTH),
+                                     "This should always fit within this buffer.");
+            if (friendlyName != M_NULLPTR)
+            {
+                M_IGNORE_SAFE_ERRNO_CALL(safe_strncpy(device->os_info.thirdFriendlyName,
+                                                      sizeof(device->os_info.thirdFriendlyName), friendlyName,
+                                                      OS_THIRD_HANDLE_NAME_LENGTH),
                                          "This should always fit within this buffer.");
             }
 #else

--- a/include/sg_helper.h
+++ b/include/sg_helper.h
@@ -262,9 +262,11 @@ extern "C"
     M_PARAM_RO(1)
     M_PARAM_WO(2)
     M_PARAM_WO(3)
+    M_PARAM_WO(4)
     eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL       handle,
                                               char* M_NONNULL* M_NULLABLE genericHandle,
-                                              char* M_NONNULL* M_NULLABLE blockHandle);
+                                              char* M_NONNULL* M_NULLABLE blockHandle,
+                                              char* M_NONNULL* M_NULLABLE blockGenericHandle);
 
     OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Lock_Device(const tDevice* M_NONNULL device);
 

--- a/include/sg_io_v4.h
+++ b/include/sg_io_v4.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! \file sg_helper.h
+//! \brief Defines the constants structures specific to Linux's SG interface.
+//! \copyright
+//! Do NOT modify or remove this copyright and license
+//!
+//! Copyright (c) 2012-2026 Seagate Technology LLC and/or its Affiliates, All Rights Reserved
+//!
+//! This software is subject to the terms of the Mozilla Public License, v. 2.0.
+//! If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#define BSG_PROTOCOL_SCSI               0
+
+#define BSG_SUB_PROTOCOL_SCSI_CMD       0
+#define BSG_SUB_PROTOCOL_SCSI_TMF       1
+#define BSG_SUB_PROTOCOL_SCSI_TRANSPORT 2
+
+/* v4 SG_IO flags */
+#define SG_FLAG_DIRECT_IO   1
+#define SG_FLAG_MMAP_IO     4
+#define SG_FLAG_NO_DXFER    0x10000
+#define SG_FLAG_Q_AT_TAIL   0x10
+#define SG_FLAG_Q_AT_HEAD   0x20
+
+#define SGV4_FLAG_DIRECT_IO SG_FLAG_DIRECT_IO
+#define SGV4_FLAG_MMAP_IO   SG_FLAG_MMAP_IO
+#define SGV4_FLAG_NO_DXFER  SG_FLAG_NO_DXFER
+#define SGV4_FLAG_Q_AT_TAIL SG_FLAG_Q_AT_TAIL
+#define SGV4_FLAG_Q_AT_HEAD SG_FLAG_Q_AT_HEAD
+#define SGV4_FLAG_IMMED     0x400
+
+/* SG_IO info field output */
+#define SG_INFO_OK_MASK        0x1
+#define SG_INFO_OK             0x0
+#define SG_INFO_CHECK          0x1
+#define SG_INFO_DIRECT_IO_MASK 0x6
+#define SG_INFO_INDIRECT_IO    0x0
+#define SG_INFO_DIRECT_IO      0x2
+#define SG_INFO_MIXED_IO       0x4
+
+    /* v4 interface structure
+     * Always use this version for cross-compilation compatibility.
+     * This ensures consistent struct layout regardless of system headers.
+     */
+    struct sg_io_v4
+    {
+        __s32 guard;       /* [i] 'Q' to differentiate from v3 */
+        __u32 protocol;    /* [i] 0 -> SCSI , .... */
+        __u32 subprotocol; /* [i] 0 -> SCSI command, 1 -> SCSI task management function, .... */
+
+        __u32 request_len;      /* [i] in bytes */
+        __u64 request;          /* [i], [*i] {SCSI: cdb} */
+        __u64 request_tag;      /* [i] {SCSI: task tag (only if flagged)} */
+        __u32 request_attr;     /* [i] {SCSI: task attribute} */
+        __u32 request_priority; /* [i] {SCSI: task priority} */
+        __u32 request_extra;    /* [i] {spare, for padding} */
+        __u32 max_response_len; /* [i] in bytes */
+        __u64 response;         /* [i], [*o] {SCSI: (auto)sense data} */
+
+        /* "dout_": data out (to device); "din_": data in (from device) */
+        __u32 dout_iovec_count; /* [i] 0 -> "flat" dout transfer else
+                       dout_xfer points to array of iovec */
+        __u32 dout_xfer_len;    /* [i] bytes to be transferred to device */
+        __u32 din_iovec_count;  /* [i] 0 -> "flat" din transfer */
+        __u32 din_xfer_len;     /* [i] bytes to be transferred from device */
+        __u64 dout_xferp;       /* [i], [*i] */
+        __u64 din_xferp;        /* [i], [*o] */
+
+        __u32 timeout;  /* [i] units: millisecond */
+        __u32 flags;    /* [i] bit mask */
+        __u64 usr_ptr;  /* [i->o] unused internally */
+        __u32 spare_in; /* [i] */
+
+        __u32 driver_status;    /* [o] 0 -> ok */
+        __u32 transport_status; /* [o] 0 -> ok */
+        __u32 device_status;    /* [o] {SCSI: command completion status} */
+        __u32 retry_delay;      /* [o] {SCSI: status auxiliary information} */
+        __u32 info;             /* [o] additional information */
+        __u32 duration;         /* [o] time to complete, in milliseconds */
+        __u32 response_len;     /* [o] bytes of response actually written */
+        __s32 din_resid;        /* [o] din_xfer_len - actual_din_xfer_len */
+        __s32 dout_resid;       /* [o] dout_xfer_len - actual_dout_xfer_len */
+        __u64 generated_tag;    /* [o] {SCSI: transport generated task tag} */
+        __u32 spare_out;        /* [o] */
+
+        __u32 padding;
+    };
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/common_public.c
+++ b/src/common_public.c
@@ -1417,9 +1417,11 @@ OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int    
                         {
                             char* genName   = M_NULLPTR;
                             char* blockName = M_NULLPTR;
+                            char* bsgHandle = M_NULLPTR;
                             if (SUCCESS ==
-                                map_Block_To_Generic_Handle((*scanDeviceList)[deviceCountToBeShown].displayHandle,
-                                                            &genName, &blockName))
+                                    map_Block_To_Generic_Handle((*scanDeviceList)[deviceCountToBeShown].displayHandle,
+                                                                &genName, &blockName, &bsgHandle) &&
+                                (genName != M_NULLPTR && blockName != M_NULLPTR))
                             {
                                 if (0 > snprintf_err_handle((*scanDeviceList)[deviceCountToBeShown].displayHandle,
                                                             SCAN_DISPLAY_HANDLE_STRING_LENGTH, "%s<->%s", genName,
@@ -1435,9 +1437,11 @@ OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int    
                         {
                             char* genName   = M_NULLPTR;
                             char* blockName = M_NULLPTR;
+                            char* bsgHandle = M_NULLPTR;
                             if (SUCCESS ==
-                                map_Block_To_Generic_Handle((*scanDeviceList)[deviceCountToBeShown].displayHandle,
-                                                            &genName, &blockName))
+                                    map_Block_To_Generic_Handle((*scanDeviceList)[deviceCountToBeShown].displayHandle,
+                                                                &genName, &blockName, &bsgHandle) &&
+                                blockName != M_NULLPTR)
                             {
                                 if (0 > snprintf_err_handle((*scanDeviceList)[deviceCountToBeShown].displayHandle,
                                                             SCAN_DISPLAY_HANDLE_STRING_LENGTH, "/dev/%s", blockName))

--- a/src/common_public.c
+++ b/src/common_public.c
@@ -1014,11 +1014,22 @@ OPENSEA_TRANSPORT_API void print_Low_Level_Info(const tDevice* M_NONNULL device)
         {
             printf("\t\t\tSecond Handle name: %s\n", device->os_info.secondName);
             printf("\t\t\tSecond Handle friendly name: %s\n", device->os_info.secondFriendlyName);
-            if (device->os_info.secondHandleOpened)
-            {
-                print_str("\t\t\tSecond handle is open\n");
-            }
         }
+#    if !defined(VMK_CROSS_COMP)
+        if (device->os_info.thirdHandleValid)
+        {
+            printf("\t\t\tThird Handle name: %s\n", device->os_info.thirdName);
+            printf("\t\t\tThird Handle friendly name: %s\n", device->os_info.thirdFriendlyName);
+        }
+        if (device->os_info.fd2Opened)
+        {
+            print_str("\t\t\tSecond handle is open\n");
+        }
+        if (device->os_info.fd3Opened)
+        {
+            print_str("\t\t\tThird handle is open\n");
+        }
+#    endif
         if (device->os_info.sgDriverVersion.driverVersionValid)
         {
             print_str("\t\t\tSG Driver Version:\n");

--- a/src/hpux_helper.c
+++ b/src/hpux_helper.c
@@ -775,14 +775,6 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues close_Device(tDevice* dev)
         retValue                = close(dev->os_info.fd);
         dev->os_info.last_error = errno;
 
-        // if (dev->os_info.secondHandleValid && dev->os_info.secondHandleOpened)
-        // {
-        //     if (close(dev->os_info.fd2) == 0)
-        //     {
-        //         dev->os_info.fd2 = -1;
-        //     }
-        // }
-
         if (retValue == 0)
         {
             dev->os_info.fd = -1;

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -105,6 +105,15 @@
 #            pragma message "No NVMe header detected with __has_include. Assuming no NVMe support."
 #        endif
 #    endif
+#    if __has_include(<linux/bsg.h>)
+#        if defined(_DEBUG)
+#            pragma message "Using linux/bsg.h"
+#        endif
+#        include <linux/bsg.h>
+#        if !defined(SEA_BSG_IOCTL_H)
+#            define SEA_BSG_IOCTL_H
+#        endif
+#    endif
 #else
 #    if defined(SEA_NVME_IOCTL_H)
 #        include <linux/nvme_ioctl.h>
@@ -1274,8 +1283,9 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
         else // not NVMe, so we need to do some investigation of the handle. NOTE: this requires 2.6 and later kernel
              // since it reads a link in the /sys/class/ filesystem
         {
-            bool incomingBlock = false; // only set for SD!
-            bool bsg           = false;
+            // bool incomingBlock = false; // only set for SD!
+            bool incomingBSG = false;
+            bool incomingSG  = false;
             DECLARE_ZERO_INIT_ARRAY(char, incomingHandleClassPath, PATH_MAX);
             if (0 != safe_strcat(incomingHandleClassPath, PATH_MAX, "/sys/class/"))
             {
@@ -1287,11 +1297,11 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                 {
                     return;
                 }
-                incomingBlock = true;
+                // incomingBlock = true;
             }
             else if (is_Block_SCSI_Generic_Handle(handle))
             {
-                bsg = true;
+                incomingBSG = true;
                 if (0 != safe_strcat(incomingHandleClassPath, PATH_MAX, "bsg/"))
                 {
                     return;
@@ -1299,6 +1309,7 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
             }
             else if (is_SCSI_Generic_Handle(handle))
             {
+                incomingSG = true;
                 if (0 != safe_strcat(incomingHandleClassPath, PATH_MAX, "scsi_generic/"))
                 {
                     return;
@@ -1368,7 +1379,7 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                         get_Linux_SYS_FS_SCSI_Device_File_Info(sysFsInfo);
 
                         char* baseLink = basename(inHandleLink);
-                        if (bsg)
+                        if (incomingBSG)
                         {
                             if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
                                                     "/dev/bsg/%s", baseLink) < 0)
@@ -1377,7 +1388,8 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                                 return;
                             }
                         }
-                        else
+                        else // for both sg and sd, set accordingly. We are setting the block handle also as primary
+                             // here, but change it later to the bsg or sg
                         {
                             if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH, "/dev/%s",
                                                     baseLink) < 0)
@@ -1392,65 +1404,146 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                         // Lastly, call the mapping function to get the matching block handle and check what we got to
                         // set ATAPI, TAPE or leave as-is. Setting these is necessary to prevent talking to ATAPI as HDD
                         // due to overlapping A1h opcode
-                        char* block = M_NULLPTR;
-                        char* gen   = M_NULLPTR;
-                        if (SUCCESS == map_Block_To_Generic_Handle(handle, &gen, &block))
+                        char* blockHandle = M_NULLPTR;
+                        char* genHandle   = M_NULLPTR;
+                        char* bsgHandle   = M_NULLPTR;
+                        if (SUCCESS == map_Block_To_Generic_Handle(handle, &genHandle, &blockHandle, &bsgHandle))
                         {
-                            // printf("successfully mapped the handle. gen = %s\tblock=%s\n", gen, block);
-                            // Our incoming handle SHOULD always be sg/bsg, but just in case, we need to check before we
-                            // setup the second handle (mapped handle) information
-                            if (incomingBlock)
+                            if (genHandle != M_NULLPTR)
                             {
-                                // block device handle was sent into here (and we made it this far...unlikely)
-                                // Secondary handle will be a generic handle
-                                if (is_Block_SCSI_Generic_Handle(gen))
+#if defined(_DEBUG)
+                                printf("genHandle = %s\t", genHandle);
+#endif
+                            }
+                            if (blockHandle != M_NULLPTR)
+                            {
+#if defined(_DEBUG)
+                                printf("blockHandle = %s\t", blockHandle);
+#endif
+                            }
+                            if (bsgHandle != M_NULLPTR)
+                            {
+#if defined(_DEBUG)
+                                printf("blockGenericHandle = %s", bsgHandle);
+#endif
+                            }
+#if defined(_DEBUG)
+                            printf("\n");
+#endif
+
+                            if (incomingSG)
+                            {
+                                if (bsgHandle != M_NULLPTR) // save secondary handle name as bsg handle
                                 {
                                     if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
-                                                            "/dev/bsg/%s", gen) < 0)
+                                                            "/dev/bsg/%s", bsgHandle) < 0)
                                     {
-                                        safe_free(&block);
-                                        safe_free(&gen);
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
                                         return;
                                     }
                                 }
-                                else
+                                else if (blockHandle != M_NULLPTR) // save secondary handle name as block handle
                                 {
                                     if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
-                                                            "/dev/%s", gen) < 0)
+                                                            "/dev/%s", blockHandle) < 0)
                                     {
-                                        safe_free(&gen);
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
                                         return;
                                     }
                                 }
                             }
-                            else
+                            else if (incomingBSG)
                             {
-                                // generic handle was sent in
-                                // secondary handle will be a block handle
-                                if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
-                                                        "/dev/%s", block) < 0)
+                                if (genHandle != M_NULLPTR) // save secondary handle name as sg handle
                                 {
-                                    safe_free(&block);
-                                    return;
+                                    if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
+                                                            "/dev/%s", genHandle) < 0)
+                                    {
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
+                                        return;
+                                    }
+                                }
+                                else if (blockHandle != M_NULLPTR) // save secondary handle name as block handle
+                                {
+                                    if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
+                                                            "/dev/%s", blockHandle) < 0)
+                                    {
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
+                                        return;
+                                    }
+                                }
+                            }
+                            else // for block handle change the primary handle as well
+                            {
+                                if (bsgHandle != M_NULLPTR) // save primary handle name as bsg handle
+                                {
+                                    if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
+                                                            "/dev/bsg/%s", bsgHandle) < 0)
+                                    {
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
+                                        return;
+                                    }
+                                }
+                                else if (genHandle != M_NULLPTR) // save primary handle name as sg handle
+                                {
+                                    if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
+                                                            "/dev/%s", genHandle) < 0)
+                                    {
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
+                                        return;
+                                    }
+                                }
+
+                                // set block handle as secondary handle
+                                if (blockHandle != M_NULLPTR)
+                                {
+                                    if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
+                                                            "/dev/%s", blockHandle) < 0)
+                                    {
+                                        safe_free(&blockHandle);
+                                        safe_free(&genHandle);
+                                        safe_free(&bsgHandle);
+                                        safe_free(&duphandle);
+                                        return;
+                                    }
                                 }
                             }
 
-                            if (strstr(block, "sr") || strstr(block, "scd"))
+                            if (strstr(blockHandle, "sr") || strstr(blockHandle, "scd"))
                             {
                                 sysFsInfo->drive_type = ATAPI_DRIVE;
                             }
-                            else if (strstr(block, "st"))
+                            else if (strstr(blockHandle, "st"))
                             {
                                 sysFsInfo->drive_type = LEGACY_TAPE_DRIVE;
                             }
-                            else if (strstr(block, "ses"))
+                            else if (strstr(blockHandle, "ses"))
                             {
                                 // scsi enclosure services
                             }
                         }
                         // print_str("Finish handle mapping\n");
-                        safe_free(&block);
-                        safe_free(&gen);
+                        safe_free(&blockHandle);
+                        safe_free(&genHandle);
+                        safe_free(&bsgHandle);
                     }
                     else
                     {
@@ -1522,19 +1615,87 @@ static void set_Device_Fields_From_Handle(const char* M_NONNULL handle, tDevice*
     }
 }
 
+static eReturnValues find_Link_In_ClassPath(const char* classPath,
+                                            const char* className,
+                                            const char* inHandleLink,
+                                            char**      handleName)
+{
+    eReturnValues   ret = UNKNOWN;
+    struct dirent** classList;
+
+    int numberOfItems =
+        scandir(classPath, &classList, M_NULLPTR /*not filtering anything. Just go through each item*/, alphasort);
+
+    for (int iter = 0; iter < numberOfItems && ret == UNKNOWN; ++iter)
+    {
+        // now we need to read the link for classPath/d_name into a buffer...then compare it to the one we
+        // read earlier.
+        size_t      tempLen = safe_strlen(classPath) + safe_strlen(classList[iter]->d_name) + 1;
+        char*       temp    = M_REINTERPRET_CAST(char*, safe_calloc(tempLen, sizeof(char)));
+        struct stat tempStat;
+        safe_memset(&tempStat, sizeof(struct stat), 0, sizeof(struct stat));
+        snprintf_err_handle(temp, tempLen, "%s%s", classPath, classList[iter]->d_name);
+        if (lstat(temp, &tempStat) == 0 && S_ISLNK(tempStat.st_mode)) /*check if this is a link*/
+        {
+            DECLARE_ZERO_INIT_ARRAY(char, mapLink, PATH_MAX);
+            if (readlink(temp, mapLink, PATH_MAX) > 0)
+            {
+#if defined(_DEBUG)
+                printf("read link as: %s\n", mapLink);
+#endif
+                // now, we need to check the links and see if they match.
+                // NOTE: If we are in the block class, we will see sda, sda1, sda 2. These are all matches
+                // (technically)
+                // We SHOULD match on the first disk without partition numbers since we did alphasort
+                // We need to match up until the class name (ex: block, bsg, scsi_generic)
+                char* classPtr = strstr(mapLink, className);
+                // need to match up to the classname
+                if (M_NULLPTR != classPtr &&
+                    strncmp(mapLink, inHandleLink,
+                            (M_STATIC_CAST(uintptr_t, classPtr) - M_STATIC_CAST(uintptr_t, mapLink))) == 0)
+                {
+                    ret = SUCCESS;
+#if defined(_DEBUG)
+                    printf("found match as: %s\n", mapLink);
+#endif
+                    if (0 != safe_strndup(handleName, basename(classPtr), safe_strlen(classPtr)))
+                    {
+                        ret = MEMORY_FAILURE;
+                    }
+                    break;
+                }
+            }
+        }
+        safe_free(&temp);
+    }
+    for (int classiter = 0; classiter < numberOfItems; ++classiter)
+    {
+        safe_free_dirent(&classList[classiter]);
+    }
+    safe_free_dirent(M_REINTERPRET_CAST(struct dirent**, &classList));
+
+    return ret;
+}
+
 // map a block handle (sd) to a generic handle (sg or bsg)
 // incoming handle can be either sd, sg, or bsg type
 // This depends on mapping in the file system provided by 2.6 and later.
 M_PARAM_RO(1)
 M_PARAM_WO(2)
 M_PARAM_WO(3)
-eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle, char** genericHandle, char** blockHandle)
+M_PARAM_WO(4)
+eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle,
+                                          char**                genericHandle,
+                                          char**                blockHandle,
+                                          char**                blockGenericHandle)
 {
-
     if (handle == M_NULLPTR)
     {
         return BAD_PARAMETER;
     }
+
+    eReturnValues ret               = FAILURE;
+    bool          atLeastOneMapping = false;
 
     // if the handle passed in contains "nvme" then we know it's a device on the nvme interface
     if (strstr(handle, "nvme") != M_NULLPTR)
@@ -1543,7 +1704,8 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle, char** g
     }
     else
     {
-        bool incomingBlock = false; // only set for SD!
+        bool incomingBlock   = false; // only set for SD!
+        bool incomingGeneric = false;
         DECLARE_ZERO_INIT_ARRAY(char, incomingHandleClassPath, PATH_MAX);
         if (0 != safe_strcat(incomingHandleClassPath, PATH_MAX, "/sys/class/"))
         {
@@ -1574,7 +1736,9 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle, char** g
                 perror("Failure setting scsi_generic into incomingHandleClassPath in map_Block_To_Generic_Handle");
                 return MEMORY_FAILURE;
             }
+            incomingGeneric = true;
         }
+
         // first make sure this directory exists
         struct stat inHandleStat;
         if (stat(incomingHandleClassPath, &inHandleStat) == 0 && S_ISDIR(inHandleStat.st_mode))
@@ -1595,199 +1759,159 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle, char** g
             DECLARE_ZERO_INIT_ARRAY(char, inHandleLink, PATH_MAX);
             if (readlink(incomingHandleClassPath, inHandleLink, PATH_MAX) > 0)
             {
-                // printf("full in handleLink = %s\n", inHandleLink);
+#if defined(_DEBUG)
+                printf("full in handleLink = %s\n", inHandleLink);
+#endif
                 // now we need to map it to a generic handle (sg...if sg not available, bsg)
-                const char* scsiGenericClass = "/sys/class/scsi_generic/";
-                const char* bsgClass         = "/sys/class/bsg/";
-                const char* blockClass       = "/sys/class/block/";
+                const char* scsiGenericClassPath = "/sys/class/scsi_generic/";
+                const char* bsgClassPath         = "/sys/class/bsg/";
+                const char* blockClassPath       = "/sys/class/block/";
+                const char* scsiGenericClassName = "scsi_generic";
+                const char* bsgClassName         = "bsg";
+                const char* blockClassName       = "block";
                 struct stat mapStat;
-                DECLARE_ZERO_INIT_ARRAY(char, classPath, PATH_MAX);
-                bool bsg = false;
+                bool        scanBSG   = false;
+                bool        scanSG    = false;
+                bool        scanBlock = false;
                 if (incomingBlock)
                 {
-                    // check for sg, then bsg
-                    if (stat(scsiGenericClass, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+                    if (0 != safe_strndup(blockHandle, basename(handle), safe_strlen(basename(handle))))
                     {
-                        if (safe_strcpy(classPath, PATH_MAX, scsiGenericClass) != 0)
-                        {
-                            perror("Failure setting scsi_generic class path in map_Block_To_Generic_Handle");
-                            safe_free(&dupHandle);
-                            return MEMORY_FAILURE;
-                        }
+                        safe_free(&dupHandle);
+                        return NOT_SUPPORTED;
                     }
-                    else if (stat(bsgClass, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+
+                    // check for sg, then bsg
+                    if (stat(scsiGenericClassPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
                     {
-                        if (safe_strcpy(classPath, PATH_MAX, bsgClass) != 0)
+                        scanSG = true;
+                    }
+
+                    if (stat(bsgClassPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+                    {
+                        scanBSG = true;
+                    }
+
+                    if (!scanSG && !scanBSG) // could not find either sg or bsg
+                    {
+                        print_str("could not map to generic or block-generic class");
+                        safe_free(&dupHandle);
+                        return NOT_SUPPORTED;
+                    }
+                }
+                else if (incomingGeneric)
+                {
+                    if (0 != safe_strndup(genericHandle, basename(handle), safe_strlen(basename(handle))))
+                    {
+                        safe_free(&dupHandle);
+                        return NOT_SUPPORTED;
+                    }
+
+                    // check for bsg, then block
+                    if (stat(bsgClassPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+                    {
+                        scanBSG = true;
+                    }
+
+                    if (stat(blockClassPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+                    {
+                        scanBlock = true;
+                    }
+
+                    if (!scanBSG && !scanBlock) // could not find either sg or block
+                    {
+                        print_str("could not map to block-generic or block class");
+                        safe_free(&dupHandle);
+                        return NOT_SUPPORTED;
+                    }
+                }
+                else // incoming is block-generic
+                {
+                    if (0 != safe_strndup(blockGenericHandle, basename(handle), safe_strlen(basename(handle))))
+                    {
+                        safe_free(&dupHandle);
+                        return NOT_SUPPORTED;
+                    }
+
+                    // check for generic and then block
+                    if (stat(scsiGenericClassPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+                    {
+                        scanSG = true;
+                    }
+
+                    if (stat(blockClassPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode))
+                    {
+                        scanBlock = true;
+                    }
+
+                    if (!scanSG && !scanBlock) // could not find either sg or block
+                    {
+                        print_str("could not map to generic or block class");
+                        safe_free(&dupHandle);
+                        return NOT_SUPPORTED;
+                    }
+                }
+
+                // now we need to loop through each think in the class folder, read the link, and check if we match.
+                if (scanBSG)
+                {
+                    eReturnValues scanRet =
+                        find_Link_In_ClassPath(bsgClassPath, bsgClassName, inHandleLink, blockGenericHandle);
+                    if (scanRet != SUCCESS)
+                    {
+#if defined(_DEBUG)
+                        print_str("Could not find map for BSG class");
+#endif
+                        if (scanRet == MEMORY_FAILURE)
                         {
-                            perror("Failure setting bsg class path in map_Block_To_Generic_Handle");
                             safe_free(&dupHandle);
                             return MEMORY_FAILURE;
                         }
-                        bsg = true;
                     }
                     else
-                    {
-                        // print_str("could not map to generic class");
-                        safe_free(&dupHandle);
-                        return NOT_SUPPORTED;
-                    }
+                        atLeastOneMapping = true;
                 }
-                else
+
+                if (scanSG)
                 {
-                    // check for block
-                    if (safe_strcpy(classPath, PATH_MAX, blockClass) != 0)
+                    eReturnValues scanRet =
+                        find_Link_In_ClassPath(scsiGenericClassPath, scsiGenericClassName, inHandleLink, genericHandle);
+                    if (scanRet != SUCCESS)
                     {
-                        perror("Failure setting block class path in map_Block_To_Generic_Handle");
-                        safe_free(&dupHandle);
-                        return MEMORY_FAILURE;
-                    }
-                    if (!(stat(classPath, &mapStat) == 0 && S_ISDIR(mapStat.st_mode)))
-                    {
-                        // print_str("could not map to block class");
-                        safe_free(&dupHandle);
-                        return NOT_SUPPORTED;
-                    }
-                }
-                // now we need to loop through each think in the class folder, read the link, and check if we match.
-                struct dirent** classList;
-                int             numberOfItems = scandir(classPath, &classList,
-                                                        M_NULLPTR /*not filtering anything. Just go through each item*/, alphasort);
-                if (numberOfItems < 0)
-                {
-                    perror("Failure scanning class directory in map_Block_To_Generic_Handle");
-                    safe_free(&dupHandle);
-                    return MEMORY_FAILURE;
-                }
-                eReturnValues ret = UNKNOWN;
-                for (int iter = 0; iter < numberOfItems && ret == UNKNOWN; ++iter)
-                {
-                    // now we need to read the link for classPath/d_name into a buffer...then compare it to the one we
-                    // read earlier.
-                    size_t tempLen = safe_strlen(classPath) + safe_strlen(classList[iter]->d_name) + 1;
-                    char*  temp    = M_REINTERPRET_CAST(char*, safe_calloc(tempLen, sizeof(char)));
-                    if (!temp)
-                    {
-                        perror("Failure allocating memory for temp in map_Block_To_Generic_Handle");
-                        safe_free(&dupHandle);
-                        return MEMORY_FAILURE;
-                    }
-                    struct stat tempStat;
-                    M_INITIALIZE_STRUCTURE(&tempStat, sizeof(struct stat));
-                    if (snprintf_err_handle(temp, tempLen, "%s%s", classPath, classList[iter]->d_name) < 0)
-                    {
-                        perror("Failure setting temp path in map_Block_To_Generic_Handle");
-                        safe_free(&temp);
-                        safe_free(&dupHandle);
-                        return MEMORY_FAILURE;
-                    }
-                    if (lstat(temp, &tempStat) == 0 && S_ISLNK(tempStat.st_mode)) /*check if this is a link*/
-                    {
-                        DECLARE_ZERO_INIT_ARRAY(char, mapLink, PATH_MAX);
-                        if (readlink(temp, mapLink, PATH_MAX) > 0)
+#if defined(_DEBUG)
+                        print_str("Could not find map for SG class");
+#endif
+                        if (scanRet == MEMORY_FAILURE)
                         {
-                            char*  className       = M_NULLPTR;
-                            size_t classNameLength = SIZE_T_C(0);
-                            // printf("read link as: %s\n", mapLink);
-                            // now, we need to check the links and see if they match.
-                            // NOTE: If we are in the block class, we will see sda, sda1, sda 2. These are all matches
-                            // (technically)
-                            //       We SHOULD match on the first disk without partition numbers since we did alphasort
-                            // We need to match up until the class name (ex: block, bsg, scsi_generic)
-                            if (incomingBlock) // block class
-                            {
-                                classNameLength = safe_strlen("scsi_generic") + 1;
-                                className       = M_REINTERPRET_CAST(char*, safe_calloc(classNameLength, sizeof(char)));
-                                if (className)
-                                {
-                                    if (snprintf_err_handle(className, classNameLength, "scsi_generic") < 0)
-                                    {
-                                        perror(
-                                            "Failure setting scsi_generic class name in map_Block_To_Generic_Handle");
-                                        safe_free(&className);
-                                        safe_free(&temp);
-                                        safe_free(&dupHandle);
-                                        return MEMORY_FAILURE;
-                                    }
-                                }
-                            }
-                            else if (bsg) // bsg class
-                            {
-                                classNameLength = safe_strlen("bsg") + 1;
-                                className       = M_REINTERPRET_CAST(char*, safe_calloc(classNameLength, sizeof(char)));
-                                if (className)
-                                {
-                                    if (snprintf_err_handle(className, classNameLength, "bsg") < 0)
-                                    {
-                                        perror("Failure setting bsg class name in map_Block_To_Generic_Handle");
-                                        safe_free(&className);
-                                        safe_free(&temp);
-                                        safe_free(&dupHandle);
-                                        return MEMORY_FAILURE;
-                                    }
-                                }
-                            }
-                            else // scsi_generic class
-                            {
-                                classNameLength = safe_strlen("block") + 1;
-                                className       = M_REINTERPRET_CAST(char*, safe_calloc(classNameLength, sizeof(char)));
-                                if (className)
-                                {
-                                    if (snprintf_err_handle(className, classNameLength, "block") < 0)
-                                    {
-                                        perror("Failure setting block class name in map_Block_To_Generic_Handle");
-                                        safe_free(&className);
-                                        safe_free(&temp);
-                                        safe_free(&dupHandle);
-                                        return MEMORY_FAILURE;
-                                    }
-                                }
-                            }
-                            if (className)
-                            {
-                                char* classPtr = strstr(mapLink, className);
-                                // need to match up to the classname
-                                if (M_NULLPTR != classPtr && strncmp(mapLink, inHandleLink,
-                                                                     (M_STATIC_CAST(uintptr_t, classPtr) -
-                                                                      M_STATIC_CAST(uintptr_t, mapLink))) == 0)
-                                {
-                                    ret = SUCCESS;
-                                    if (incomingBlock)
-                                    {
-                                        if (0 != safe_strndup(blockHandle, basehandle, safe_strlen(basehandle)) ||
-                                            0 != safe_strdup(genericHandle, basename(classPtr)))
-                                        {
-                                            ret = MEMORY_FAILURE;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        if (0 != safe_strndup(blockHandle, basename(classPtr),
-                                                              safe_strlen(basename(classPtr))) ||
-                                            0 != safe_strdup(genericHandle, basehandle))
-                                        {
-                                            ret = MEMORY_FAILURE;
-                                        }
-                                    }
-                                    safe_free(&className);
-                                    safe_free(&temp);
-                                    safe_free(&dupHandle);
-                                    break; // found a match, exit the loop
-                                }
-                            }
-                            safe_free(&className);
+                            safe_free(&dupHandle);
+                            return MEMORY_FAILURE;
                         }
                     }
-                    safe_free(&temp);
+                    else
+                        atLeastOneMapping = true;
                 }
-                for (int classiter = 0; classiter < numberOfItems; ++classiter)
+
+                if (scanBlock)
                 {
-                    safe_free_dirent(&classList[classiter]);
+                    eReturnValues scanRet =
+                        find_Link_In_ClassPath(blockClassPath, blockClassName, inHandleLink, blockHandle);
+                    if (scanRet != SUCCESS)
+                    {
+#if defined(_DEBUG)
+                        print_str("Could not find map for BLOCK class");
+#endif
+                        if (scanRet == MEMORY_FAILURE)
+                        {
+                            safe_free(&dupHandle);
+                            return MEMORY_FAILURE;
+                        }
+                    }
+                    else
+                        atLeastOneMapping = true;
                 }
-                safe_free_dirent(M_REINTERPRET_CAST(struct dirent**, &classList));
-                if (ret != UNKNOWN)
-                {
-                    return ret;
-                }
+
+                if (atLeastOneMapping)
+                    ret = SUCCESS;
             }
             else
             {
@@ -1803,7 +1927,8 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle, char** g
             return NOT_SUPPORTED;
         }
     }
-    return UNKNOWN;
+
+    return ret;
 }
 
 // This is used to open device->os_info.fd2 which is where we will store
@@ -1852,69 +1977,107 @@ static eReturnValues open_fd2(tDevice* M_NONNULL device)
     return ret;
 }
 
-#define LIN_MAX_HANDLE_LENGTH 16
+#define LIN_MAX_HANDLE_LENGTH 30
 static eReturnValues resolve_Block_Handle_To_Generic_Handle(const char* filename, char** genericHandle)
 {
-    if (is_Block_Device_Handle(filename))
+    char*         genHandle      = M_NULLPTR;
+    char*         blockHandle    = M_NULLPTR;
+    char*         blockGenHandle = M_NULLPTR;
+    eReturnValues mapResult      = map_Block_To_Generic_Handle(filename, &genHandle, &blockHandle, &blockGenHandle);
+
+    if (mapResult == SUCCESS)
     {
-        // print_str("\tBlock handle found, mapping...\n");
-        char*         genHandle   = M_NULLPTR;
-        char*         blockHandle = M_NULLPTR;
-        eReturnValues mapResult   = map_Block_To_Generic_Handle(filename, &genHandle, &blockHandle);
-#if defined(_DEBUG)
-        printf("sg = %s\tsd = %s\n", genHandle, blockHandle);
-#endif
-        if (mapResult == SUCCESS && genHandle != M_NULLPTR)
+        if (genHandle != M_NULLPTR)
         {
-            *genericHandle = M_REINTERPRET_CAST(char*, safe_calloc(LIN_MAX_HANDLE_LENGTH, sizeof(char)));
-            // print_str("Changing filename to SG device....\n");
-            if (is_SCSI_Generic_Handle(genHandle))
-            {
-                if (snprintf_err_handle(*genericHandle, LIN_MAX_HANDLE_LENGTH, "/dev/%s", genHandle) < 0)
-                {
-                    perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
-                    safe_free(genericHandle);
-                    safe_free(&genHandle);
-                    safe_free(&blockHandle);
-                    return MEMORY_FAILURE;
-                }
-            }
-            else
-            {
-                if (snprintf_err_handle(*genericHandle, LIN_MAX_HANDLE_LENGTH, "/dev/bsg/%s", genHandle) < 0)
-                {
-                    perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
-                    safe_free(genericHandle);
-                    safe_free(&genHandle);
-                    safe_free(&blockHandle);
-                    return MEMORY_FAILURE;
-                }
-            }
 #if defined(_DEBUG)
-            printf("\tfilename = %s\n", *genericHandle);
+            printf("genHandle = %s\t", genHandle);
 #endif
         }
-        else // If we can't map, let still try anyway.
+        if (blockHandle != M_NULLPTR)
         {
-            // We couldn't map the sg and sd handles, but still moving forward assuming the user will provide correct
-            // device handle
-            if (0 != safe_strdup(genericHandle, filename))
+#if defined(_DEBUG)
+            printf("blockHandle = %s\t", blockHandle);
+#endif
+        }
+        if (blockGenHandle != M_NULLPTR)
+        {
+#if defined(_DEBUG)
+            printf("blockGenericHandle = %s", blockGenHandle);
+#endif
+        }
+#if defined(_DEBUG)
+        printf("\n");
+#endif
+        // copy incoming handle name into generic first
+        *genericHandle = M_REINTERPRET_CAST(char*, safe_calloc(LIN_MAX_HANDLE_LENGTH, sizeof(char)));
+        if (snprintf_err_handle(*genericHandle, LIN_MAX_HANDLE_LENGTH, "%s", filename) < 0)
+        {
+            perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
+            safe_free(genericHandle);
+            safe_free(&genHandle);
+            safe_free(&blockHandle);
+            safe_free(&blockGenHandle);
+            return MEMORY_FAILURE;
+        }
+
+        if ((blockGenHandle != M_NULLPTR))
+        {
+            if (snprintf_err_handle(*genericHandle, LIN_MAX_HANDLE_LENGTH, "/dev/bsg/%s", blockGenHandle) < 0)
             {
+                perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
+                safe_free(genericHandle);
                 safe_free(&genHandle);
                 safe_free(&blockHandle);
+                safe_free(&blockGenHandle);
                 return MEMORY_FAILURE;
             }
         }
-        safe_free(&genHandle);
-        safe_free(&blockHandle);
+        else if (genHandle != M_NULLPTR)
+        {
+            if (snprintf_err_handle(*genericHandle, LIN_MAX_HANDLE_LENGTH, "/dev/%s", genHandle) < 0)
+            {
+                perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
+                safe_free(genericHandle);
+                safe_free(&genHandle);
+                safe_free(&blockHandle);
+                safe_free(&blockGenHandle);
+                return MEMORY_FAILURE;
+            }
+        }
+        else if (blockHandle != M_NULLPTR)
+        {
+            if (snprintf_err_handle(*genericHandle, LIN_MAX_HANDLE_LENGTH, "/dev/%s", blockHandle) < 0)
+            {
+                perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
+                safe_free(genericHandle);
+                safe_free(&genHandle);
+                safe_free(&blockHandle);
+                safe_free(&blockGenHandle);
+                return MEMORY_FAILURE;
+            }
+        }
     }
-    else
+    else // If we can't map, let still try anyway.
     {
+        // We couldn't map the sg, bsg and sd handles, but still moving forward assuming the user will provide correct
+        // device handle
         if (0 != safe_strdup(genericHandle, filename))
         {
+            perror("Failure setting generic handle name in resolve_Block_Handle_To_Generic_Handle");
+            safe_free(&genHandle);
+            safe_free(&blockHandle);
+            safe_free(&blockGenHandle);
             return MEMORY_FAILURE;
         }
     }
+    safe_free(&genHandle);
+    safe_free(&blockHandle);
+    safe_free(&blockGenHandle);
+
+#if defined(_DEBUG)
+    printf("%s: filename = %s, genericHandle = %s\n", __FUNCTION__, filename, *genericHandle);
+#endif
+
     return SUCCESS;
 }
 
@@ -2110,7 +2273,7 @@ static eReturnValues get_Lin_Device(const char* filename, tDevice* M_NONNULL dev
         }
         else // not an NVMe handle
         {
-            ret = linux_Get_SCSI_Device(device, genericHandle);
+            ret = linux_Get_SCSI_Device(device, filename);
         }
         if (ret == SUCCESS)
         {
@@ -2520,7 +2683,389 @@ static eReturnValues print_tDevice_Verbose_SGIOv3_Info(const tDevice* M_NONNULL 
     return ret;
 }
 
-M_PARAM_RW(1) eReturnValues send_sg_io(ScsiIoCtx* M_NONNULL scsiIoCtx)
+#if defined(SEA_BSG_IOCTL_H)
+static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
+{
+    struct sg_io_v4 io_hdr;
+    uint8_t*        localSenseBuffer = M_NULLPTR;
+    eReturnValues   ret              = SUCCESS;
+    DECLARE_SEATIMER(commandTimer);
+#    ifdef _DEBUG
+    printf("-->%s \n", __FUNCTION__);
+#    endif
+
+    safe_memset(&io_hdr, sizeof(struct sg_io_v4), 0, sizeof(struct sg_io_v4));
+
+    if (VERBOSITY_BUFFERS <= scsiIoCtx->device->deviceVerbosity)
+    {
+        print_str("Sending command with send_sg_io_v4\n");
+    }
+
+    io_hdr.guard       = 'Q';
+    io_hdr.protocol    = BSG_PROTOCOL_SCSI;
+    io_hdr.subprotocol = BSG_SUB_PROTOCOL_SCSI_CMD;
+
+    io_hdr.request_len = scsiIoCtx->cdbLength;
+    io_hdr.request     = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->cdb));
+
+    // Use user's sense or local?
+    if ((scsiIoCtx->senseDataSize) && (scsiIoCtx->psense != M_NULLPTR))
+    {
+        io_hdr.max_response_len = scsiIoCtx->senseDataSize;
+        io_hdr.response         = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->psense));
+    }
+    else
+    {
+        localSenseBuffer =
+            M_REINTERPRET_CAST(uint8_t*, safe_calloc_aligned(SPC3_SENSE_LEN, sizeof(uint8_t),
+                                                             scsiIoCtx->device->os_info.minimumAlignment));
+        if (!localSenseBuffer)
+        {
+            return MEMORY_FAILURE;
+        }
+        io_hdr.max_response_len = SPC3_SENSE_LEN;
+        io_hdr.response         = C_CAST(__u64, C_CAST(uintptr_t, localSenseBuffer));
+    }
+
+    switch (scsiIoCtx->direction)
+    {
+    case XFER_NO_DATA:
+        break;
+    case XFER_DATA_IN:
+        io_hdr.din_xfer_len = scsiIoCtx->dataLength;
+        io_hdr.din_xferp    = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        break;
+    case XFER_DATA_OUT:
+        io_hdr.dout_xfer_len = scsiIoCtx->dataLength;
+        io_hdr.dout_xferp    = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        break;
+    case XFER_DATA_IN_OUT:
+    case XFER_DATA_OUT_IN:
+        // v4 supports bidirectional: set both din and dout
+        io_hdr.din_xfer_len  = scsiIoCtx->dataLength;
+        io_hdr.din_xferp     = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.dout_xfer_len = scsiIoCtx->dataLength;
+        io_hdr.dout_xferp    = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        break;
+    default:
+        if (VERBOSITY_QUIET < scsiIoCtx->device->deviceVerbosity)
+        {
+            printf("%s Didn't understand direction\n", __FUNCTION__);
+        }
+        safe_free_aligned(&localSenseBuffer);
+        return BAD_PARAMETER;
+    }
+
+    // Set timeout
+    if (scsiIoCtx->device->drive_info.defaultTimeoutSeconds > 0 &&
+        scsiIoCtx->device->drive_info.defaultTimeoutSeconds > scsiIoCtx->timeout)
+    {
+        io_hdr.timeout = scsiIoCtx->device->drive_info.defaultTimeoutSeconds;
+        if (scsiIoCtx->device->drive_info.defaultTimeoutSeconds < SG_MAX_CMD_TIMEOUT_SECONDS)
+        {
+            io_hdr.timeout *= 1000; // convert to milliseconds
+        }
+        else
+        {
+            io_hdr.timeout = UINT32_MAX;
+        }
+    }
+    else
+    {
+        if (scsiIoCtx->timeout != 0)
+        {
+            io_hdr.timeout = scsiIoCtx->timeout;
+            if (scsiIoCtx->timeout < SG_MAX_CMD_TIMEOUT_SECONDS)
+            {
+                io_hdr.timeout *= 1000; // convert to milliseconds
+            }
+            else
+            {
+                io_hdr.timeout = UINT32_MAX;
+            }
+        }
+        else
+        {
+            io_hdr.timeout = DEFAULT_COMMAND_TIMEOUT * 1000;
+        }
+    }
+
+    scsiIoCtx->returnStatus.format   = 0xFF;
+    scsiIoCtx->returnStatus.senseKey = 0;
+    scsiIoCtx->returnStatus.asc      = 0;
+    scsiIoCtx->returnStatus.ascq     = 0;
+
+    start_Timer(&commandTimer);
+    int ioctlResult = ioctl(scsiIoCtx->device->os_info.fd, SG_IO, &io_hdr);
+    stop_Timer(&commandTimer);
+
+    if (ioctlResult < 0)
+    {
+        set_Device_Last_Error(scsiIoCtx->device, errno);
+        ret = OS_PASSTHROUGH_FAILURE;
+        if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+        {
+            if (scsiIoCtx->device->os_info.last_error != 0)
+            {
+                print_str("Error: ");
+                print_Errno_To_Screen(errno);
+            }
+        }
+    }
+
+    if (localSenseBuffer != M_NULLPTR)
+    {
+        safe_memcpy(scsiIoCtx->device->drive_info.lastCommandSenseData, SPC3_SENSE_LEN, localSenseBuffer,
+                    SPC3_SENSE_LEN);
+    }
+
+    // Parse sense data from response
+    if (io_hdr.response_len > 0)
+    {
+        uint8_t* responseBuf           = M_REINTERPRET_CAST(uint8_t*, C_CAST(uintptr_t, io_hdr.response));
+        scsiIoCtx->returnStatus.format = responseBuf[0];
+        get_Sense_Key_ASC_ASCQ_FRU(responseBuf, io_hdr.max_response_len, &scsiIoCtx->returnStatus.senseKey,
+                                   &scsiIoCtx->returnStatus.asc, &scsiIoCtx->returnStatus.ascq,
+                                   &scsiIoCtx->returnStatus.fru);
+    }
+
+    if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+    {
+        switch (io_hdr.info & SG_INFO_DIRECT_IO_MASK)
+        {
+        case SG_INFO_INDIRECT_IO:
+            print_str("SG v4 IO Issued as Indirect IO\n");
+            break;
+        case SG_INFO_DIRECT_IO:
+            print_str("SG v4 IO Issued as Direct IO\n");
+            break;
+        case SG_INFO_MIXED_IO:
+            print_str("SG v4 IO Issued as Mixed IO\n");
+            break;
+        default:
+            print_str("SG v4 IO Issued as Unknown IO type\n");
+            break;
+        }
+    }
+
+    if ((io_hdr.info & SG_INFO_OK_MASK) != SG_INFO_OK)
+    {
+        if (io_hdr.device_status != 0) // SAM_STAT_GOOD???
+        {
+            if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+            {
+                printf("SG Device Status = %02" PRIX8 "h", io_hdr.device_status);
+                switch (io_hdr.device_status)
+                {
+                case GOOD:
+                    print_str(" - Good\n");
+                    break;
+                case CHECK_CONDITION:
+                    print_str(" - Check Condition\n");
+                    break;
+                case CONDITION_GOOD:
+                    print_str(" - Condition Good\n");
+                    break;
+                case BUSY:
+                    print_str(" - Busy\n");
+                    break;
+                case INTERMEDIATE_GOOD:
+                    print_str(" - Intermediate Good\n");
+                    break;
+                case INTERMEDIATE_C_GOOD:
+                    print_str(" - Intermediate C Good\n");
+                    break;
+                case RESERVATION_CONFLICT:
+                    print_str(" - Reservation Conflict\n");
+                    break;
+                case COMMAND_TERMINATED:
+                    print_str(" - Command Terminated\n");
+                    break;
+                case QUEUE_FULL:
+                    print_str(" - Queue Full\n");
+                    break;
+#    if defined(TASK_ABORTED)
+                case TASK_ABORTED:
+#    else
+                case 0x20:
+#    endif
+                    print_str(" - Task Aborted\n");
+                    break;
+                default:
+                    print_str(" - Unknown Masked Status\n");
+                    break;
+                }
+            }
+            if (io_hdr.sb_len_wr == 0)
+            {
+                if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+                {
+                    print_str("\t(Masked Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
+                }
+                // No sense data back. We need to set an error since the layers above are going to look for sense data
+                // and we don't have any.
+                ret = OS_PASSTHROUGH_FAILURE;
+            }
+        }
+
+        if (io_hdr.transport_status != 0)
+        {
+            printf("SG Transport Status = %02" PRIX16 "h", io_hdr.transport_status);
+            switch (io_hdr.transport_status)
+            {
+            case OPENSEA_SG_ERR_DID_OK:
+                print_str(" - No Error\n");
+                break;
+            case OPENSEA_SG_ERR_DID_NO_CONNECT:
+                print_str(" - Could Not Connect\n");
+                break;
+            case OPENSEA_SG_ERR_DID_BUS_BUSY:
+                print_str(" - Bus Busy\n");
+                break;
+            case OPENSEA_SG_ERR_DID_TIME_OUT:
+                print_str(" - Timed Out\n");
+                break;
+            case OPENSEA_SG_ERR_DID_BAD_TARGET:
+                print_str(" - Bad Target Device\n");
+                break;
+            case OPENSEA_SG_ERR_DID_ABORT:
+                print_str(" - Abort\n");
+                break;
+            case OPENSEA_SG_ERR_DID_PARITY:
+                print_str(" - Parity Error\n");
+                break;
+            case OPENSEA_SG_ERR_DID_ERROR:
+                print_str(" - Internal Adapter Error\n");
+                break;
+            case OPENSEA_SG_ERR_DID_RESET:
+                print_str(" - SCSI Bus/Device Has Been Reset\n");
+                break;
+            case OPENSEA_SG_ERR_DID_BAD_INTR:
+                print_str(" - Bad Interrupt\n");
+                break;
+            case OPENSEA_SG_ERR_DID_PASSTHROUGH:
+                print_str(" - Forced Passthrough Past Mid-Layer\n");
+                break;
+            case OPENSEA_SG_ERR_DID_SOFT_ERROR:
+                print_str(" - Soft Error, Retry?\n");
+                break;
+            default:
+                print_str(" - Unknown Host Status\n");
+                break;
+            }
+
+            // host/transport level failure
+            if (io_hdr.response_len == 0)
+            {
+                // Special case for MegaRAID and controllers based on MegaRAID.
+                // These controllers block the command and set "Internal Adapter Error" with no other information
+                // available.
+                // TODO: Need to test and see if SAT passthrough trusted send/receive are also blocked to add them to
+                // this case. -TJE
+                if (io_hdr.transport_status == OPENSEA_SG_ERR_DID_ERROR &&
+                    (scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_IN ||
+                     scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_OUT))
+                {
+                    if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+                    {
+                        print_str("\tSpecial Case: Security Protocol Command Blocked\n");
+                    }
+                    ret = OS_COMMAND_BLOCKED;
+                }
+                else
+                {
+                    if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+                    {
+                        print_str("\t(Transport Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
+                    }
+                    ret = OS_PASSTHROUGH_FAILURE;
+                }
+            }
+        }
+
+        if (io_hdr.driver_status != 0)
+        {
+            if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+            {
+                printf("SG Driver Status = %02" PRIX16 "h", io_hdr.driver_status);
+                switch (io_hdr.driver_status & OPENSEA_SG_ERR_DRIVER_MASK)
+                {
+                case OPENSEA_SG_ERR_DRIVER_OK:
+                    print_str(" - Driver OK");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_BUSY:
+                    print_str(" - Driver Busy");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_SOFT:
+                    print_str(" - Driver Soft Error");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_MEDIA:
+                    print_str(" - Driver Media Error");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_ERROR:
+                    print_str(" - Driver Error");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_INVALID:
+                    print_str(" - Driver Invalid");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_TIMEOUT:
+                    print_str(" - Driver Timeout");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_HARD:
+                    print_str(" - Driver Hard Error");
+                    break;
+                case OPENSEA_SG_ERR_DRIVER_SENSE:
+                    print_str(" - Driver Sense Data Available");
+                    break;
+                default:
+                    print_str(" - Unknown Driver Error");
+                    break;
+                }
+                // now error suggestions
+                switch (io_hdr.driver_status & OPENSEA_SG_ERR_SUGGEST_MASK)
+                {
+                case OPENSEA_SG_ERR_SUGGEST_NONE:
+                    break; // no suggestions, nothing necessary to print
+                case OPENSEA_SG_ERR_SUGGEST_RETRY:
+                    print_str(" - Suggest Retry");
+                    break;
+                case OPENSEA_SG_ERR_SUGGEST_ABORT:
+                    print_str(" - Suggest Abort");
+                    break;
+                case OPENSEA_SG_ERR_SUGGEST_REMAP:
+                    print_str(" - Suggest Remap");
+                    break;
+                case OPENSEA_SG_ERR_SUGGEST_DIE:
+                    print_str(" - Suggest Die");
+                    break;
+                case OPENSEA_SG_ERR_SUGGEST_SENSE:
+                    print_str(" - Suggest Sense");
+                    break;
+                default:
+                    print_str(" - Unknown suggestion");
+                    break;
+                }
+                print_str("\n");
+            }
+
+            // driver-level failure
+            if (io_hdr.response_len == 0)
+            {
+                ret = OS_PASSTHROUGH_FAILURE;
+            }
+        }
+    }
+
+    scsiIoCtx->device->drive_info.lastCommandTimeNanoSeconds = get_Nano_Seconds(commandTimer);
+#    ifdef _DEBUG
+    printf("<--%s (%d)\n", __FUNCTION__, ret);
+#    endif
+    safe_free_aligned(&localSenseBuffer);
+    return ret;
+}
+#endif
+
+static eReturnValues send_sg_io_v3(ScsiIoCtx* M_NONNULL scsiIoCtx)
 {
     sg_io_hdr_t   io_hdr;
     uint8_t*      localSenseBuffer = M_NULLPTR;
@@ -2691,6 +3236,31 @@ M_PARAM_RW(1) eReturnValues send_sg_io(ScsiIoCtx* M_NONNULL scsiIoCtx)
 #endif
     safe_free_aligned(&localSenseBuffer);
     return ret;
+}
+
+eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
+{
+#if defined(SEA_BSG_IOCTL_H)
+    if (is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) ||
+        (scsiIoCtx->device->os_info.secondHandleValid &&
+         is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.secondName)))
+    {
+        // BSG handles: must use v4, SG_GET_VERSION_NUM doesn't apply
+        return send_sg_io_v4(scsiIoCtx);
+    }
+    else if (is_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) &&
+             scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&
+             scsiIoCtx->device->os_info.sgDriverVersion.majorVersion >= 4)
+    {
+        // SG v4 driver on /dev/sg*: can use v4 (preferred) or v3
+        return send_sg_io_v4(scsiIoCtx);
+    }
+    else
+#endif
+    {
+        // SG driver 3.x on /dev/sg*, or /dev/sd* block handles: use v3
+        return send_sg_io_v3(scsiIoCtx);
+    }
 }
 
 static int nvme_filter(const struct dirent* entry)

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -105,7 +105,6 @@
 #            pragma message "No NVMe header detected with __has_include. Assuming no NVMe support."
 #        endif
 #    endif
-
 #    if __has_include(<linux/bsg.h>)
 #        if defined(_DEBUG)
 #            pragma message "Using linux/bsg.h"
@@ -114,11 +113,11 @@
 #        if !defined(SEA_BSG_IOCTL_H)
 #            define SEA_BSG_IOCTL_H
 #        endif
-#    endif
-     // Always include our sg_io_v4.h for consistent struct definition (cross-compilation compatible)
-#    include "sg_io_v4.h"
-#    if !defined(SEA_BSG_IOCTL_H)
-#        define SEA_BSG_IOCTL_H
+#    else
+#        include "sg_io_v4.h" // Always include our sg_io_v4.h for consistent struct definition (cross-compilation compatible)
+#        if !defined(SEA_BSG_IOCTL_H)
+#            define SEA_BSG_IOCTL_H
+#        endif
 #    endif
 #else
 #    if defined(SEA_NVME_IOCTL_H)
@@ -133,11 +132,11 @@
 #    endif
 #    if defined(SEA_BSG_IOCTL_H)
 #        include <linux/bsg.h>
-#    endif
-     // Always include our sg_io_v4.h for consistent struct definition (cross-compilation compatible)
-#    include "sg_io_v4.h"
-#    if !defined(SEA_BSG_IOCTL_H)
-#        define SEA_BSG_IOCTL_H
+#    else
+#        include "sg_io_v4.h" // Always include our sg_io_v4.h for consistent struct definition (cross-compilation compatible)
+#        if !defined(SEA_BSG_IOCTL_H)
+#            define SEA_BSG_IOCTL_H
+#        endif
 #    endif
 #endif
 

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -105,6 +105,7 @@
 #            pragma message "No NVMe header detected with __has_include. Assuming no NVMe support."
 #        endif
 #    endif
+
 #    if __has_include(<linux/bsg.h>)
 #        if defined(_DEBUG)
 #            pragma message "Using linux/bsg.h"
@@ -113,6 +114,11 @@
 #        if !defined(SEA_BSG_IOCTL_H)
 #            define SEA_BSG_IOCTL_H
 #        endif
+#    endif
+     // Always include our sg_io_v4.h for consistent struct definition (cross-compilation compatible)
+#    include "sg_io_v4.h"
+#    if !defined(SEA_BSG_IOCTL_H)
+#        define SEA_BSG_IOCTL_H
 #    endif
 #else
 #    if defined(SEA_NVME_IOCTL_H)
@@ -124,6 +130,14 @@
 #    else
 #        pragma message                                                                                                \
             "No NVMe header detected. Assuming no NVMe support. Define one of the following to include the correct NVMe header: SEA_NVME_IOCTL_H, SEA_NVME_H, or SEA_UAPI_NVME_H\nThese specify whether the NVMe IOCTL is in /usr/include/linux/nvme_ioctl.h, /usr/include/linux/nvme.h, or /usr/include/uapi/nvme.h"
+#    endif
+#    if defined(SEA_BSG_IOCTL_H)
+#        include <linux/bsg.h>
+#    endif
+     // Always include our sg_io_v4.h for consistent struct definition (cross-compilation compatible)
+#    include "sg_io_v4.h"
+#    if !defined(SEA_BSG_IOCTL_H)
+#        define SEA_BSG_IOCTL_H
 #    endif
 #endif
 
@@ -2709,7 +2723,7 @@ static eReturnValues print_tDevice_Verbose_SGIOv3_Info(const tDevice* M_NONNULL 
 
 #if defined(SEA_BSG_IOCTL_H)
 // Helper function to print SG IO direct/indirect/mixed type information
-static void print_sgv4_io_direct_type_info(const tDevice* M_NONNULL device, sg_io_v4* M_NONNULL io_hdr)
+static void print_sgv4_io_direct_type_info(const tDevice* M_NONNULL device, struct sg_io_v4* M_NONNULL io_hdr)
 {
     switch (io_hdr->info & SG_INFO_DIRECT_IO_MASK)
     {
@@ -2730,9 +2744,9 @@ static void print_sgv4_io_direct_type_info(const tDevice* M_NONNULL device, sg_i
 
 // Helper function to print SG IO device status
 // Returns modified ret value if sense data unavailable
-static eReturnValues print_sgv4_io_device_status(const tDevice* M_NONNULL device,
-                                                 sg_io_v4* M_NONNULL      io_hdr,
-                                                 eReturnValues            ret)
+static eReturnValues print_sgv4_io_device_status(const tDevice* M_NONNULL   device,
+                                                 struct sg_io_v4* M_NONNULL io_hdr,
+                                                 eReturnValues              ret)
 {
     if (io_hdr->device_status == 0)
         return ret;
@@ -2793,10 +2807,10 @@ static eReturnValues print_sgv4_io_device_status(const tDevice* M_NONNULL device
 
 // Helper function to print SG IO transport status (SCSI adapter/bus status)
 // Returns modified ret value if sense data unavailable or special cases
-static eReturnValues print_sgv4_io_transport_status(const tDevice* M_NONNULL device,
-                                                    sg_io_v4* M_NONNULL      io_hdr,
-                                                    ScsiIoCtx* M_NONNULL     scsiIoCtx,
-                                                    eReturnValues            ret)
+static eReturnValues print_sgv4_io_transport_status(const tDevice* M_NONNULL   device,
+                                                    struct sg_io_v4* M_NONNULL io_hdr,
+                                                    ScsiIoCtx* M_NONNULL       scsiIoCtx,
+                                                    eReturnValues              ret)
 {
     if (io_hdr->transport_status == 0)
         return ret;
@@ -2849,7 +2863,7 @@ static eReturnValues print_sgv4_io_transport_status(const tDevice* M_NONNULL dev
     if (io_hdr->response_len == 0)
     {
         // Special case for MegaRAID controllers that block certain commands
-        if (io_hdr->host_status == OPENSEA_SG_ERR_DID_ERROR &&
+        if (io_hdr->transport_status == OPENSEA_SG_ERR_DID_ERROR &&
             (scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_IN ||
              scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_OUT))
         {
@@ -2871,9 +2885,9 @@ static eReturnValues print_sgv4_io_transport_status(const tDevice* M_NONNULL dev
 
 // Helper function to print SG IO driver status (Linux SCSI driver status)
 // Returns modified ret value if sense data unavailable
-static eReturnValues print_sgv4_io_driver_status(const tDevice* M_NONNULL device,
-                                                 sg_io_v4* M_NONNULL      io_hdr,
-                                                 eReturnValues            ret)
+static eReturnValues print_sgv4_io_driver_status(const tDevice* M_NONNULL   device,
+                                                 struct sg_io_v4* M_NONNULL io_hdr,
+                                                 eReturnValues              ret)
 {
     if (io_hdr->driver_status == 0)
         return ret;
@@ -2951,10 +2965,10 @@ static eReturnValues print_sgv4_io_driver_status(const tDevice* M_NONNULL device
 }
 
 // Main helper: Print all SG_IOv4 diagnostic information with device-aware verbosity
-static eReturnValues print_tDevice_Verbose_SGIOv4_Info(const tDevice* M_NONNULL device,
-                                                       sg_io_v4* M_NONNULL      io_hdr,
-                                                       ScsiIoCtx* M_NONNULL     scsiIoCtx,
-                                                       eReturnValues            ret)
+static eReturnValues print_tDevice_Verbose_SGIOv4_Info(const tDevice* M_NONNULL   device,
+                                                       struct sg_io_v4* M_NONNULL io_hdr,
+                                                       ScsiIoCtx* M_NONNULL       scsiIoCtx,
+                                                       eReturnValues              ret)
 {
     print_sgv4_io_direct_type_info(device, io_hdr);
 
@@ -2979,7 +2993,7 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
 #    endif
 
     // safe_memset(&io_hdr, sizeof(struct sg_io_v4), 0, sizeof(struct sg_io_v4));
-    M_INITIALIZE_STRUCTURE(&io_hdr, sizeof(sg_io_v4));
+    M_INITIALIZE_STRUCTURE(&io_hdr, sizeof(struct sg_io_v4));
 
     print_tDevice_Verbose_String(scsiIoCtx->device, VERBOSITY_BUFFERS, "Sending command with send_sg_io_v4\n");
 
@@ -2988,13 +3002,13 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
     io_hdr.subprotocol = BSG_SUB_PROTOCOL_SCSI_CMD;
 
     io_hdr.request_len = scsiIoCtx->cdbLength;
-    io_hdr.request     = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->cdb));
+    io_hdr.request     = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, scsiIoCtx->cdb));
 
     // Use user's sense or local?
     if ((scsiIoCtx->senseDataSize) && (scsiIoCtx->psense != M_NULLPTR))
     {
         io_hdr.max_response_len = scsiIoCtx->senseDataSize;
-        io_hdr.response         = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->psense));
+        io_hdr.response         = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, scsiIoCtx->psense));
     }
     else
     {
@@ -3006,7 +3020,7 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
             return MEMORY_FAILURE;
         }
         io_hdr.max_response_len = SPC3_SENSE_LEN;
-        io_hdr.response         = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, localSenseBuffer));
+        io_hdr.response         = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, localSenseBuffer));
     }
 
     switch (scsiIoCtx->direction)
@@ -3015,19 +3029,19 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
         break;
     case XFER_DATA_IN:
         io_hdr.din_xfer_len = scsiIoCtx->dataLength;
-        io_hdr.din_xferp    = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.din_xferp    = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         break;
     case XFER_DATA_OUT:
         io_hdr.dout_xfer_len = scsiIoCtx->dataLength;
-        io_hdr.dout_xferp    = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.dout_xferp    = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         break;
     case XFER_DATA_IN_OUT:
     case XFER_DATA_OUT_IN:
         // v4 supports bidirectional: set both din and dout
         io_hdr.din_xfer_len  = scsiIoCtx->dataLength;
-        io_hdr.din_xferp     = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.din_xferp     = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         io_hdr.dout_xfer_len = scsiIoCtx->dataLength;
-        io_hdr.dout_xferp    = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.dout_xferp    = M_STATIC_CAST(uint64_t, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         break;
     default:
         print_tDevice_Verbose_Formatted_String(scsiIoCtx->device, VERBOSITY_QUIET, "%s Didn't understand direction\n",
@@ -3117,7 +3131,7 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
     {
         uint8_t* responseBuf           = M_REINTERPRET_CAST(uint8_t*, C_CAST(uintptr_t, io_hdr.response));
         scsiIoCtx->returnStatus.format = responseBuf[0];
-        get_Sense_Key_ASC_ASCQ_FRU(responseBuf, io_hdr.max_response_len, &scsiIoCtx->returnStatus.senseKey,
+        get_Sense_Key_ASC_ASCQ_FRU(responseBuf, io_hdr.response_len, &scsiIoCtx->returnStatus.senseKey,
                                    &scsiIoCtx->returnStatus.asc, &scsiIoCtx->returnStatus.ascq,
                                    &scsiIoCtx->returnStatus.fru);
     }
@@ -3314,12 +3328,8 @@ eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
         (scsiIoCtx->device->os_info.secondHandleValid &&
          is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.secondName)))
     {
-        // BSG handles: pre 4.18, v3, otherwise v4
-        if (scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&
-            scsiIoCtx->device->os_info.sgDriverVersion.majorVersion >= 4)
-            return send_sg_io_v4(scsiIoCtx);
-        else
-            return send_sg_io_v3(scsiIoCtx);
+        // BSG handles: SEA_BSG_IOCTL_H guarantees kernel 4.18+ with v4 support
+        return send_sg_io_v4(scsiIoCtx);
     }
     else if (is_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) &&
              scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&
@@ -3331,7 +3341,7 @@ eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
     else
 #endif
     {
-        // SG driver 3.x on /dev/sg*, or /dev/sd* block handles: use v3
+        // SG driver 3.x on /dev/sg*, pre-4.18 BSG, or /dev/sd* block handles: use v3
         return send_sg_io_v3(scsiIoCtx);
     }
 }

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -1612,6 +1612,17 @@ static void set_Device_Fields_From_Handle(const char* M_NONNULL handle, tDevice*
             safe_free(&dupSecond);
             device->os_info.secondHandleValid = true;
         }
+
+        // Copy HCTL (Host:Channel:Target:LUN) from sysfs if available
+        // This is needed for BSG handles on pre-4.18 kernels where SG_GET_SCSI_ID ioctl fails
+        if (!device->os_info.scsiAddressValid)
+        {
+            device->os_info.scsiAddressValid    = true;
+            device->os_info.scsiAddress.host    = sysFsInfo.scsiAddress.host;
+            device->os_info.scsiAddress.channel = sysFsInfo.scsiAddress.channel;
+            device->os_info.scsiAddress.target  = sysFsInfo.scsiAddress.target;
+            device->os_info.scsiAddress.lun     = sysFsInfo.scsiAddress.lun;
+        }
     }
 }
 
@@ -1775,7 +1786,7 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle,
                 bool        scanBlock = false;
                 if (incomingBlock)
                 {
-                    if (0 != safe_strndup(blockHandle, basename(handle), safe_strlen(basename(handle))))
+                    if (0 != safe_strndup(blockHandle, basehandle, safe_strlen(basehandle)))
                     {
                         safe_free(&dupHandle);
                         return NOT_SUPPORTED;
@@ -1801,7 +1812,7 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle,
                 }
                 else if (incomingGeneric)
                 {
-                    if (0 != safe_strndup(genericHandle, basename(handle), safe_strlen(basename(handle))))
+                    if (0 != safe_strndup(genericHandle, basehandle, safe_strlen(basehandle)))
                     {
                         safe_free(&dupHandle);
                         return NOT_SUPPORTED;
@@ -1827,7 +1838,7 @@ eReturnValues map_Block_To_Generic_Handle(const char* M_NONNULL handle,
                 }
                 else // incoming is block-generic
                 {
-                    if (0 != safe_strndup(blockGenericHandle, basename(handle), safe_strlen(basename(handle))))
+                    if (0 != safe_strndup(blockGenericHandle, basehandle, safe_strlen(basehandle)))
                     {
                         safe_free(&dupHandle);
                         return NOT_SUPPORTED;
@@ -2081,7 +2092,7 @@ static eReturnValues resolve_Block_Handle_To_Generic_Handle(const char* filename
     return SUCCESS;
 }
 
-static eReturnValues linux_Get_NVMe_Device(tDevice* device, const char* deviceHandle)
+static eReturnValues linux_Get_NVMe_Device(tDevice* M_NONNULL device, const char* deviceHandle)
 {
 #if !defined(DISABLE_NVME_PASSTHROUGH)
     eReturnValues ret = SUCCESS;
@@ -2117,8 +2128,7 @@ static eReturnValues linux_Get_NVMe_Device(tDevice* device, const char* deviceHa
 
 static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char* deviceHandle)
 {
-    eReturnValues ret = SUCCESS;
-    int           k   = 0;
+    int k = 0;
 #if defined(_DEBUG)
     print_str("Getting SG SCSI address\n");
 #endif
@@ -2129,6 +2139,7 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
     if (getHctl == 0 && errno == 0) // when this succeeds, both of these will be zeros
     {
         // print_str("Got hctlInfo\n");
+        device->os_info.scsiAddressValid    = true;
         device->os_info.scsiAddress.host    = C_CAST(uint8_t, hctlInfo.host_no);
         device->os_info.scsiAddress.channel = C_CAST(uint8_t, hctlInfo.channel);
         device->os_info.scsiAddress.target  = C_CAST(uint8_t, hctlInfo.scsi_id);
@@ -2149,10 +2160,21 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
     // From http://tldp.org/HOWTO/SCSI-Generic-HOWTO/pexample.html
     if ((ioctl(device->os_info.fd, SG_GET_VERSION_NUM, &k) < 0) || (k < 30000))
     {
-        printf("%s: SG_GET_VERSION_NUM on %s failed version=%d\n", __FUNCTION__, deviceHandle, k);
-        perror("SG_GET_VERSION_NUM");
-        close(device->os_info.fd);
-        ret = FAILURE;
+        if (is_Block_SCSI_Generic_Handle(deviceHandle))
+        {
+            // BSG handle on pre-4.18: version check failed, but we'll use v3 SG_IO instead of v4
+            device->os_info.sgDriverVersion.driverVersionValid = true;
+            device->os_info.sgDriverVersion.majorVersion       = 3; // Default to v3 for BSG on older kernels
+            device->os_info.sgDriverVersion.minorVersion       = 0;
+            device->os_info.sgDriverVersion.revision           = 0;
+        }
+        else
+        {
+            printf("%s: SG_GET_VERSION_NUM on %s failed version=%d\n", __FUNCTION__, deviceHandle, k);
+            perror("SG_GET_VERSION_NUM");
+            close(device->os_info.fd);
+            return FAILURE;
+        }
     }
     else
     {
@@ -2164,29 +2186,30 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
         device->os_info.sgDriverVersion.revision =
             C_CAST(uint8_t, k - (device->os_info.sgDriverVersion.majorVersion * 10000) -
                                 (device->os_info.sgDriverVersion.minorVersion * 100));
-
-        // set scsi interface and scsi drive until we know otherwise
-        set_Device_DriveType(device, SCSI_DRIVE);
-        set_Device_InterfaceType(device, SCSI_INTERFACE);
-        set_Device_MediaType(device, MEDIA_HDD);
-        // now have the device information fields set
-#if defined(_DEBUG)
-        print_str("Setting interface, drive type, secondary handles\n");
-#endif
-        set_Device_Fields_From_Handle(deviceHandle, device);
-        setup_Passthrough_Hacks_By_ID(device);
-
-#if defined(_DEBUG)
-        printf("name = %s\t friendly name = %s\n2ndName = %s\t2ndFName = %s\n", get_Device_Handle_Name(device),
-               get_Device_Handle_Friendly_Name(device), device->os_info.secondName, device->os_info.secondFriendlyName);
-        printf("h:c:t:l = %u:%u:%u:%u\n", device->os_info.scsiAddress.host, device->os_info.scsiAddress.channel,
-               device->os_info.scsiAddress.target, device->os_info.scsiAddress.lun);
-
-        printf("SG driver version = %u.%u.%u\n", device->os_info.sgDriverVersion.majorVersion,
-               device->os_info.sgDriverVersion.minorVersion, device->os_info.sgDriverVersion.revision);
-#endif
     }
-    return ret;
+
+    // set scsi interface and scsi drive until we know otherwise
+    set_Device_DriveType(device, SCSI_DRIVE);
+    set_Device_InterfaceType(device, SCSI_INTERFACE);
+    set_Device_MediaType(device, MEDIA_HDD);
+    // now have the device information fields set
+#if defined(_DEBUG)
+    print_str("Setting interface, drive type, secondary handles\n");
+#endif
+    set_Device_Fields_From_Handle(deviceHandle, device);
+    setup_Passthrough_Hacks_By_ID(device);
+
+#if defined(_DEBUG)
+    printf("name = %s\t friendly name = %s\n2ndName = %s\t2ndFName = %s\n", get_Device_Handle_Name(device),
+           get_Device_Handle_Friendly_Name(device), device->os_info.secondName, device->os_info.secondFriendlyName);
+    printf("h:c:t:l = %u:%u:%u:%u\n", device->os_info.scsiAddress.host, device->os_info.scsiAddress.channel,
+           device->os_info.scsiAddress.target, device->os_info.scsiAddress.lun);
+
+    printf("SG driver version = %u.%u.%u\n", device->os_info.sgDriverVersion.majorVersion,
+           device->os_info.sgDriverVersion.minorVersion, device->os_info.sgDriverVersion.revision);
+#endif
+
+    return SUCCESS;
 }
 
 M_NONNULL_PARAM_LIST(1, 2)
@@ -2235,6 +2258,7 @@ static eReturnValues get_Lin_Device(const char* filename, tDevice* M_NONNULL dev
         safe_free(&genericHandle);
         return ret;
     }
+
     if (handleFlags == POSIX_HANDLE_FLAGS_DEFAULT)
     {
         set_Device_Handle_Open_Flags(device, HANDLE_FLAGS_DEFAULT);
@@ -2255,7 +2279,7 @@ static eReturnValues get_Lin_Device(const char* filename, tDevice* M_NONNULL dev
         set_Device_DriveType(device, SCSI_DRIVE);
         set_Device_InterfaceType(device, SCSI_INTERFACE);
         set_Device_MediaType(device, MEDIA_HDD);
-        set_Device_Fields_From_Handle(genericHandle, device);
+        set_Device_Fields_From_Handle(filename, device);
         setup_Passthrough_Hacks_By_ID(device);
         set_Device_Partition_Info(&device->os_info.fileSystemInfo, device->os_info.secondHandleValid
                                                                        ? device->os_info.secondName
@@ -2414,7 +2438,7 @@ M_PARAM_RO(1) eReturnValues send_IO(ScsiIoCtx* M_NONNULL scsiIoCtx)
 }
 
 // Helper function to print SG IO direct/indirect/mixed type information
-static void print_sg_io_direct_type_info(const tDevice* M_NONNULL device, sg_io_hdr_t* M_NONNULL io_hdr)
+static void print_sgv3_io_direct_type_info(const tDevice* M_NONNULL device, sg_io_hdr_t* M_NONNULL io_hdr)
 {
     switch (io_hdr->info & SG_INFO_DIRECT_IO_MASK)
     {
@@ -2435,9 +2459,9 @@ static void print_sg_io_direct_type_info(const tDevice* M_NONNULL device, sg_io_
 
 // Helper function to print SG IO masked status (SCSI device status)
 // Returns modified ret value if sense data unavailable
-static eReturnValues print_sg_io_masked_status(const tDevice* M_NONNULL device,
-                                               sg_io_hdr_t* M_NONNULL   io_hdr,
-                                               eReturnValues            ret)
+static eReturnValues print_sgv3_io_masked_status(const tDevice* M_NONNULL device,
+                                                 sg_io_hdr_t* M_NONNULL   io_hdr,
+                                                 eReturnValues            ret)
 {
     if (io_hdr->masked_status == 0)
         return ret;
@@ -2497,7 +2521,7 @@ static eReturnValues print_sg_io_masked_status(const tDevice* M_NONNULL device,
 }
 
 // Helper function to print SG IO message status
-static void print_sg_io_message_status(const tDevice* M_NONNULL device, sg_io_hdr_t* M_NONNULL io_hdr)
+static void print_sgv3_io_message_status(const tDevice* M_NONNULL device, sg_io_hdr_t* M_NONNULL io_hdr)
 {
     if (io_hdr->msg_status == 0)
         return;
@@ -2508,10 +2532,10 @@ static void print_sg_io_message_status(const tDevice* M_NONNULL device, sg_io_hd
 
 // Helper function to print SG IO host status (SCSI adapter/bus status)
 // Returns modified ret value if sense data unavailable or special cases
-static eReturnValues print_sg_io_host_status(const tDevice* M_NONNULL device,
-                                             sg_io_hdr_t* M_NONNULL   io_hdr,
-                                             ScsiIoCtx* M_NONNULL     scsiIoCtx,
-                                             eReturnValues            ret)
+static eReturnValues print_sgv3_io_host_status(const tDevice* M_NONNULL device,
+                                               sg_io_hdr_t* M_NONNULL   io_hdr,
+                                               ScsiIoCtx* M_NONNULL     scsiIoCtx,
+                                               eReturnValues            ret)
 {
     if (io_hdr->host_status == 0)
         return ret;
@@ -2585,9 +2609,9 @@ static eReturnValues print_sg_io_host_status(const tDevice* M_NONNULL device,
 
 // Helper function to print SG IO driver status (Linux SCSI driver status)
 // Returns modified ret value if sense data unavailable
-static eReturnValues print_sg_io_driver_status(const tDevice* M_NONNULL device,
-                                               sg_io_hdr_t* M_NONNULL   io_hdr,
-                                               eReturnValues            ret)
+static eReturnValues print_sgv3_io_driver_status(const tDevice* M_NONNULL device,
+                                                 sg_io_hdr_t* M_NONNULL   io_hdr,
+                                                 eReturnValues            ret)
 {
     if (io_hdr->driver_status == 0)
         return ret;
@@ -2670,20 +2694,280 @@ static eReturnValues print_tDevice_Verbose_SGIOv3_Info(const tDevice* M_NONNULL 
                                                        ScsiIoCtx* M_NONNULL     scsiIoCtx,
                                                        eReturnValues            ret)
 {
-    print_sg_io_direct_type_info(device, io_hdr);
+    print_sgv3_io_direct_type_info(device, io_hdr);
 
     if ((io_hdr->info & SG_INFO_OK_MASK) != SG_INFO_OK)
     {
-        ret = print_sg_io_masked_status(device, io_hdr, ret);
-        print_sg_io_message_status(device, io_hdr);
-        ret = print_sg_io_host_status(device, io_hdr, scsiIoCtx, ret);
-        ret = print_sg_io_driver_status(device, io_hdr, ret);
+        ret = print_sgv3_io_masked_status(device, io_hdr, ret);
+        print_sgv3_io_message_status(device, io_hdr);
+        ret = print_sgv3_io_host_status(device, io_hdr, scsiIoCtx, ret);
+        ret = print_sgv3_io_driver_status(device, io_hdr, ret);
     }
 
     return ret;
 }
 
 #if defined(SEA_BSG_IOCTL_H)
+// Helper function to print SG IO direct/indirect/mixed type information
+static void print_sgv4_io_direct_type_info(const tDevice* M_NONNULL device, sg_io_v4* M_NONNULL io_hdr)
+{
+    switch (io_hdr->info & SG_INFO_DIRECT_IO_MASK)
+    {
+    case SG_INFO_INDIRECT_IO:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, "SG IO Issued as Indirect IO\n");
+        break;
+    case SG_INFO_DIRECT_IO:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, "SG IO Issued as Direct IO\n");
+        break;
+    case SG_INFO_MIXED_IO:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, "SG IO Issued as Mixed IO\n");
+        break;
+    default:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, "SG IO Issued as Unknown IO type\n");
+        break;
+    }
+}
+
+// Helper function to print SG IO device status
+// Returns modified ret value if sense data unavailable
+static eReturnValues print_sgv4_io_device_status(const tDevice* M_NONNULL device,
+                                                 sg_io_v4* M_NONNULL      io_hdr,
+                                                 eReturnValues            ret)
+{
+    if (io_hdr->device_status == 0)
+        return ret;
+
+    print_tDevice_Verbose_Formatted_String(device, VERBOSITY_COMMAND_VERBOSE, "SG Device Status = %02" PRIX8 "h",
+                                           io_hdr->device_status);
+    switch (io_hdr->device_status)
+    {
+    case GOOD:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Good\n");
+        break;
+    case CHECK_CONDITION:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Check Condition\n");
+        break;
+    case CONDITION_GOOD:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Condition Good\n");
+        break;
+    case BUSY:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Busy\n");
+        break;
+    case INTERMEDIATE_GOOD:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Intermediate Good\n");
+        break;
+    case INTERMEDIATE_C_GOOD:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Intermediate C Good\n");
+        break;
+    case RESERVATION_CONFLICT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Reservation Conflict\n");
+        break;
+    case COMMAND_TERMINATED:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Command Terminated\n");
+        break;
+    case QUEUE_FULL:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Queue Full\n");
+        break;
+#    if defined(TASK_ABORTED)
+    case TASK_ABORTED:
+#    else
+    case 0x20:
+#    endif
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Task Aborted\n");
+        break;
+    default:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Unknown Masked Status\n");
+        break;
+    }
+
+    // If no sense data available, set error status
+    if (io_hdr->response_len == 0)
+    {
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE,
+                                     "\t(Device Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
+        ret = OS_PASSTHROUGH_FAILURE;
+    }
+
+    return ret;
+}
+
+// Helper function to print SG IO transport status (SCSI adapter/bus status)
+// Returns modified ret value if sense data unavailable or special cases
+static eReturnValues print_sgv4_io_transport_status(const tDevice* M_NONNULL device,
+                                                    sg_io_v4* M_NONNULL      io_hdr,
+                                                    ScsiIoCtx* M_NONNULL     scsiIoCtx,
+                                                    eReturnValues            ret)
+{
+    if (io_hdr->transport_status == 0)
+        return ret;
+
+    print_tDevice_Verbose_Formatted_String(device, VERBOSITY_COMMAND_VERBOSE, "SG Transport Status = %02" PRIX16 "h",
+                                           io_hdr->transport_status);
+    switch (io_hdr->transport_status)
+    {
+    case OPENSEA_SG_ERR_DID_OK:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - No Error\n");
+        break;
+    case OPENSEA_SG_ERR_DID_NO_CONNECT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Could Not Connect\n");
+        break;
+    case OPENSEA_SG_ERR_DID_BUS_BUSY:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Bus Busy\n");
+        break;
+    case OPENSEA_SG_ERR_DID_TIME_OUT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Timed Out\n");
+        break;
+    case OPENSEA_SG_ERR_DID_BAD_TARGET:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Bad Target Device\n");
+        break;
+    case OPENSEA_SG_ERR_DID_ABORT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Abort\n");
+        break;
+    case OPENSEA_SG_ERR_DID_PARITY:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Parity Error\n");
+        break;
+    case OPENSEA_SG_ERR_DID_ERROR:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Internal Adapter Error\n");
+        break;
+    case OPENSEA_SG_ERR_DID_RESET:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - SCSI Bus/Device Has Been Reset\n");
+        break;
+    case OPENSEA_SG_ERR_DID_BAD_INTR:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Bad Interrupt\n");
+        break;
+    case OPENSEA_SG_ERR_DID_PASSTHROUGH:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Forced Passthrough Past Mid-Layer\n");
+        break;
+    case OPENSEA_SG_ERR_DID_SOFT_ERROR:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Soft Error, Retry?\n");
+        break;
+    default:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Unknown Host Status\n");
+        break;
+    }
+
+    if (io_hdr->response_len == 0)
+    {
+        // Special case for MegaRAID controllers that block certain commands
+        if (io_hdr->host_status == OPENSEA_SG_ERR_DID_ERROR &&
+            (scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_IN ||
+             scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_OUT))
+        {
+            print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE,
+                                         "\tSpecial Case: Security Protocol Command Blocked\n");
+            ret = OS_COMMAND_BLOCKED;
+        }
+        else
+        {
+            print_tDevice_Verbose_String(
+                device, VERBOSITY_COMMAND_VERBOSE,
+                "\t(Transport Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
+            ret = OS_PASSTHROUGH_FAILURE;
+        }
+    }
+
+    return ret;
+}
+
+// Helper function to print SG IO driver status (Linux SCSI driver status)
+// Returns modified ret value if sense data unavailable
+static eReturnValues print_sgv4_io_driver_status(const tDevice* M_NONNULL device,
+                                                 sg_io_v4* M_NONNULL      io_hdr,
+                                                 eReturnValues            ret)
+{
+    if (io_hdr->driver_status == 0)
+        return ret;
+
+    print_tDevice_Verbose_Formatted_String(device, VERBOSITY_COMMAND_VERBOSE, "SG Driver Status = %02" PRIX16 "h",
+                                           io_hdr->driver_status);
+    switch (io_hdr->driver_status & OPENSEA_SG_ERR_DRIVER_MASK)
+    {
+    case OPENSEA_SG_ERR_DRIVER_OK:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver OK");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_BUSY:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Busy");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_SOFT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Soft Error");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_MEDIA:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Media Error");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_ERROR:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Error");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_INVALID:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Invalid");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_TIMEOUT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Timeout");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_HARD:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Hard Error");
+        break;
+    case OPENSEA_SG_ERR_DRIVER_SENSE:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Driver Sense Data Available");
+        break;
+    default:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Unknown Driver Error");
+        break;
+    }
+
+    // Error suggestions
+    switch (io_hdr->driver_status & OPENSEA_SG_ERR_SUGGEST_MASK)
+    {
+    case OPENSEA_SG_ERR_SUGGEST_NONE:
+        break; // no suggestions
+    case OPENSEA_SG_ERR_SUGGEST_RETRY:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Suggest Retry");
+        break;
+    case OPENSEA_SG_ERR_SUGGEST_ABORT:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Suggest Abort");
+        break;
+    case OPENSEA_SG_ERR_SUGGEST_REMAP:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Suggest Remap");
+        break;
+    case OPENSEA_SG_ERR_SUGGEST_DIE:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Suggest Die");
+        break;
+    case OPENSEA_SG_ERR_SUGGEST_SENSE:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Suggest Sense");
+        break;
+    default:
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, " - Unknown suggestion");
+        break;
+    }
+    print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE, "\n");
+
+    if (io_hdr->response_len == 0)
+    {
+        print_tDevice_Verbose_String(device, VERBOSITY_COMMAND_VERBOSE,
+                                     "\t(Driver Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
+        ret = OS_PASSTHROUGH_FAILURE;
+    }
+
+    return ret;
+}
+
+// Main helper: Print all SG_IOv4 diagnostic information with device-aware verbosity
+static eReturnValues print_tDevice_Verbose_SGIOv4_Info(const tDevice* M_NONNULL device,
+                                                       sg_io_v4* M_NONNULL      io_hdr,
+                                                       ScsiIoCtx* M_NONNULL     scsiIoCtx,
+                                                       eReturnValues            ret)
+{
+    print_sgv4_io_direct_type_info(device, io_hdr);
+
+    if ((io_hdr->info & SG_INFO_OK_MASK) != SG_INFO_OK)
+    {
+        ret = print_sgv4_io_device_status(device, io_hdr, ret);
+        ret = print_sgv4_io_transport_status(device, io_hdr, scsiIoCtx, ret);
+        ret = print_sgv4_io_driver_status(device, io_hdr, ret);
+    }
+
+    return ret;
+}
+
 static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
 {
     struct sg_io_v4 io_hdr;
@@ -2694,25 +2978,23 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
     printf("-->%s \n", __FUNCTION__);
 #    endif
 
-    safe_memset(&io_hdr, sizeof(struct sg_io_v4), 0, sizeof(struct sg_io_v4));
+    // safe_memset(&io_hdr, sizeof(struct sg_io_v4), 0, sizeof(struct sg_io_v4));
+    M_INITIALIZE_STRUCTURE(&io_hdr, sizeof(sg_io_v4));
 
-    if (VERBOSITY_BUFFERS <= scsiIoCtx->device->deviceVerbosity)
-    {
-        print_str("Sending command with send_sg_io_v4\n");
-    }
+    print_tDevice_Verbose_String(scsiIoCtx->device, VERBOSITY_BUFFERS, "Sending command with send_sg_io_v4\n");
 
     io_hdr.guard       = 'Q';
     io_hdr.protocol    = BSG_PROTOCOL_SCSI;
     io_hdr.subprotocol = BSG_SUB_PROTOCOL_SCSI_CMD;
 
     io_hdr.request_len = scsiIoCtx->cdbLength;
-    io_hdr.request     = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->cdb));
+    io_hdr.request     = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->cdb));
 
     // Use user's sense or local?
     if ((scsiIoCtx->senseDataSize) && (scsiIoCtx->psense != M_NULLPTR))
     {
         io_hdr.max_response_len = scsiIoCtx->senseDataSize;
-        io_hdr.response         = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->psense));
+        io_hdr.response         = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->psense));
     }
     else
     {
@@ -2724,7 +3006,7 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
             return MEMORY_FAILURE;
         }
         io_hdr.max_response_len = SPC3_SENSE_LEN;
-        io_hdr.response         = C_CAST(__u64, C_CAST(uintptr_t, localSenseBuffer));
+        io_hdr.response         = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, localSenseBuffer));
     }
 
     switch (scsiIoCtx->direction)
@@ -2733,41 +3015,41 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
         break;
     case XFER_DATA_IN:
         io_hdr.din_xfer_len = scsiIoCtx->dataLength;
-        io_hdr.din_xferp    = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.din_xferp    = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         break;
     case XFER_DATA_OUT:
         io_hdr.dout_xfer_len = scsiIoCtx->dataLength;
-        io_hdr.dout_xferp    = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.dout_xferp    = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         break;
     case XFER_DATA_IN_OUT:
     case XFER_DATA_OUT_IN:
         // v4 supports bidirectional: set both din and dout
         io_hdr.din_xfer_len  = scsiIoCtx->dataLength;
-        io_hdr.din_xferp     = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.din_xferp     = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         io_hdr.dout_xfer_len = scsiIoCtx->dataLength;
-        io_hdr.dout_xferp    = C_CAST(__u64, C_CAST(uintptr_t, scsiIoCtx->pdata));
+        io_hdr.dout_xferp    = M_STATIC_CAST(__u64, M_STATIC_CAST(uintptr_t, scsiIoCtx->pdata));
         break;
     default:
-        if (VERBOSITY_QUIET < scsiIoCtx->device->deviceVerbosity)
-        {
-            printf("%s Didn't understand direction\n", __FUNCTION__);
-        }
+        print_tDevice_Verbose_Formatted_String(scsiIoCtx->device, VERBOSITY_QUIET, "%s Didn't understand direction\n",
+                                               __func__);
         safe_free_aligned(&localSenseBuffer);
         return BAD_PARAMETER;
     }
 
     // Set timeout
-    if (scsiIoCtx->device->drive_info.defaultTimeoutSeconds > 0 &&
-        scsiIoCtx->device->drive_info.defaultTimeoutSeconds > scsiIoCtx->timeout)
+    const uint32_t deviceTimeout = get_tDevice_Default_Command_Timeout(scsiIoCtx->device);
+    if (deviceTimeout > 0 && deviceTimeout > scsiIoCtx->timeout)
     {
-        io_hdr.timeout = scsiIoCtx->device->drive_info.defaultTimeoutSeconds;
-        if (scsiIoCtx->device->drive_info.defaultTimeoutSeconds < SG_MAX_CMD_TIMEOUT_SECONDS)
+        io_hdr.timeout = deviceTimeout;
+        // this check is to make sure on commands that set a very VERY large timeout (*cough* *cough* ata security) that
+        // we DON'T do a conversion and leave the time as the max...
+        if (deviceTimeout < SG_MAX_CMD_TIMEOUT_SECONDS)
         {
             io_hdr.timeout *= 1000; // convert to milliseconds
         }
         else
         {
-            io_hdr.timeout = UINT32_MAX;
+            io_hdr.timeout = UINT32_MAX; // no timeout or maximum timeout
         }
     }
     else
@@ -2775,18 +3057,20 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
         if (scsiIoCtx->timeout != 0)
         {
             io_hdr.timeout = scsiIoCtx->timeout;
+            // this check is to make sure on commands that set a very VERY large timeout (*cough* *cough* ata security)
+            // that we DON'T do a conversion and leave the time as the max...
             if (scsiIoCtx->timeout < SG_MAX_CMD_TIMEOUT_SECONDS)
             {
                 io_hdr.timeout *= 1000; // convert to milliseconds
             }
             else
             {
-                io_hdr.timeout = UINT32_MAX;
+                io_hdr.timeout = UINT32_MAX; // no timeout or maximum timeout
             }
         }
         else
         {
-            io_hdr.timeout = DEFAULT_COMMAND_TIMEOUT * 1000;
+            io_hdr.timeout = DEFAULT_COMMAND_TIMEOUT * 1000; // default to 15 second timeout
         }
     }
 
@@ -2802,21 +3086,30 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
     if (ioctlResult < 0)
     {
         set_Device_Last_Error(scsiIoCtx->device, errno);
-        ret = OS_PASSTHROUGH_FAILURE;
-        if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
+        ret           = OS_PASSTHROUGH_FAILURE;
+        errno_t error = M_STATIC_CAST(errno_t, get_Device_OS_Info_Last_Error(scsiIoCtx->device));
+        if (error != 0)
         {
-            if (scsiIoCtx->device->os_info.last_error != 0)
+            char* errormsg = get_strerror(error);
+            if (errormsg != M_NULLPTR)
             {
-                print_str("Error: ");
-                print_Errno_To_Screen(errno);
+                print_tDevice_Verbose_Formatted_String(scsiIoCtx->device, VERBOSITY_COMMAND_VERBOSE, "%d - %s", error,
+                                                       errormsg);
+                safe_free(&errormsg);
+            }
+            else
+            {
+                print_tDevice_Verbose_Formatted_String(scsiIoCtx->device, VERBOSITY_COMMAND_VERBOSE, "%d", error);
             }
         }
     }
 
     if (localSenseBuffer != M_NULLPTR)
     {
-        safe_memcpy(scsiIoCtx->device->drive_info.lastCommandSenseData, SPC3_SENSE_LEN, localSenseBuffer,
-                    SPC3_SENSE_LEN);
+        M_IGNORE_SAFE_ERRNO_CALL(
+            safe_memcpy(scsiIoCtx->device->drive_info.lastCommandSenseData, SPC3_SENSE_LEN, localSenseBuffer,
+                        SPC3_SENSE_LEN),
+            "Using exact same SPC3_SENSE_LEN for both source and destination, so this should never fail");
     }
 
     // Parse sense data from response
@@ -2829,234 +3122,10 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
                                    &scsiIoCtx->returnStatus.fru);
     }
 
-    if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
-    {
-        switch (io_hdr.info & SG_INFO_DIRECT_IO_MASK)
-        {
-        case SG_INFO_INDIRECT_IO:
-            print_str("SG v4 IO Issued as Indirect IO\n");
-            break;
-        case SG_INFO_DIRECT_IO:
-            print_str("SG v4 IO Issued as Direct IO\n");
-            break;
-        case SG_INFO_MIXED_IO:
-            print_str("SG v4 IO Issued as Mixed IO\n");
-            break;
-        default:
-            print_str("SG v4 IO Issued as Unknown IO type\n");
-            break;
-        }
-    }
+    // Print SG_IOv4 diagnostic information with device-aware verbosity
+    ret = print_tDevice_Verbose_SGIOv4_Info(scsiIoCtx->device, &io_hdr, scsiIoCtx, ret);
 
-    if ((io_hdr.info & SG_INFO_OK_MASK) != SG_INFO_OK)
-    {
-        if (io_hdr.device_status != 0) // SAM_STAT_GOOD???
-        {
-            if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
-            {
-                printf("SG Device Status = %02" PRIX8 "h", io_hdr.device_status);
-                switch (io_hdr.device_status)
-                {
-                case GOOD:
-                    print_str(" - Good\n");
-                    break;
-                case CHECK_CONDITION:
-                    print_str(" - Check Condition\n");
-                    break;
-                case CONDITION_GOOD:
-                    print_str(" - Condition Good\n");
-                    break;
-                case BUSY:
-                    print_str(" - Busy\n");
-                    break;
-                case INTERMEDIATE_GOOD:
-                    print_str(" - Intermediate Good\n");
-                    break;
-                case INTERMEDIATE_C_GOOD:
-                    print_str(" - Intermediate C Good\n");
-                    break;
-                case RESERVATION_CONFLICT:
-                    print_str(" - Reservation Conflict\n");
-                    break;
-                case COMMAND_TERMINATED:
-                    print_str(" - Command Terminated\n");
-                    break;
-                case QUEUE_FULL:
-                    print_str(" - Queue Full\n");
-                    break;
-#    if defined(TASK_ABORTED)
-                case TASK_ABORTED:
-#    else
-                case 0x20:
-#    endif
-                    print_str(" - Task Aborted\n");
-                    break;
-                default:
-                    print_str(" - Unknown Masked Status\n");
-                    break;
-                }
-            }
-            if (io_hdr.sb_len_wr == 0)
-            {
-                if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
-                {
-                    print_str("\t(Masked Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
-                }
-                // No sense data back. We need to set an error since the layers above are going to look for sense data
-                // and we don't have any.
-                ret = OS_PASSTHROUGH_FAILURE;
-            }
-        }
-
-        if (io_hdr.transport_status != 0)
-        {
-            printf("SG Transport Status = %02" PRIX16 "h", io_hdr.transport_status);
-            switch (io_hdr.transport_status)
-            {
-            case OPENSEA_SG_ERR_DID_OK:
-                print_str(" - No Error\n");
-                break;
-            case OPENSEA_SG_ERR_DID_NO_CONNECT:
-                print_str(" - Could Not Connect\n");
-                break;
-            case OPENSEA_SG_ERR_DID_BUS_BUSY:
-                print_str(" - Bus Busy\n");
-                break;
-            case OPENSEA_SG_ERR_DID_TIME_OUT:
-                print_str(" - Timed Out\n");
-                break;
-            case OPENSEA_SG_ERR_DID_BAD_TARGET:
-                print_str(" - Bad Target Device\n");
-                break;
-            case OPENSEA_SG_ERR_DID_ABORT:
-                print_str(" - Abort\n");
-                break;
-            case OPENSEA_SG_ERR_DID_PARITY:
-                print_str(" - Parity Error\n");
-                break;
-            case OPENSEA_SG_ERR_DID_ERROR:
-                print_str(" - Internal Adapter Error\n");
-                break;
-            case OPENSEA_SG_ERR_DID_RESET:
-                print_str(" - SCSI Bus/Device Has Been Reset\n");
-                break;
-            case OPENSEA_SG_ERR_DID_BAD_INTR:
-                print_str(" - Bad Interrupt\n");
-                break;
-            case OPENSEA_SG_ERR_DID_PASSTHROUGH:
-                print_str(" - Forced Passthrough Past Mid-Layer\n");
-                break;
-            case OPENSEA_SG_ERR_DID_SOFT_ERROR:
-                print_str(" - Soft Error, Retry?\n");
-                break;
-            default:
-                print_str(" - Unknown Host Status\n");
-                break;
-            }
-
-            // host/transport level failure
-            if (io_hdr.response_len == 0)
-            {
-                // Special case for MegaRAID and controllers based on MegaRAID.
-                // These controllers block the command and set "Internal Adapter Error" with no other information
-                // available.
-                // TODO: Need to test and see if SAT passthrough trusted send/receive are also blocked to add them to
-                // this case. -TJE
-                if (io_hdr.transport_status == OPENSEA_SG_ERR_DID_ERROR &&
-                    (scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_IN ||
-                     scsiIoCtx->cdb[CDB_OPERATION_CODE] == SECURITY_PROTOCOL_OUT))
-                {
-                    if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
-                    {
-                        print_str("\tSpecial Case: Security Protocol Command Blocked\n");
-                    }
-                    ret = OS_COMMAND_BLOCKED;
-                }
-                else
-                {
-                    if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
-                    {
-                        print_str("\t(Transport Status) Sense data not available, assuming OS_PASSTHROUGH_FAILURE\n");
-                    }
-                    ret = OS_PASSTHROUGH_FAILURE;
-                }
-            }
-        }
-
-        if (io_hdr.driver_status != 0)
-        {
-            if (VERBOSITY_COMMAND_VERBOSE <= scsiIoCtx->device->deviceVerbosity)
-            {
-                printf("SG Driver Status = %02" PRIX16 "h", io_hdr.driver_status);
-                switch (io_hdr.driver_status & OPENSEA_SG_ERR_DRIVER_MASK)
-                {
-                case OPENSEA_SG_ERR_DRIVER_OK:
-                    print_str(" - Driver OK");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_BUSY:
-                    print_str(" - Driver Busy");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_SOFT:
-                    print_str(" - Driver Soft Error");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_MEDIA:
-                    print_str(" - Driver Media Error");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_ERROR:
-                    print_str(" - Driver Error");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_INVALID:
-                    print_str(" - Driver Invalid");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_TIMEOUT:
-                    print_str(" - Driver Timeout");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_HARD:
-                    print_str(" - Driver Hard Error");
-                    break;
-                case OPENSEA_SG_ERR_DRIVER_SENSE:
-                    print_str(" - Driver Sense Data Available");
-                    break;
-                default:
-                    print_str(" - Unknown Driver Error");
-                    break;
-                }
-                // now error suggestions
-                switch (io_hdr.driver_status & OPENSEA_SG_ERR_SUGGEST_MASK)
-                {
-                case OPENSEA_SG_ERR_SUGGEST_NONE:
-                    break; // no suggestions, nothing necessary to print
-                case OPENSEA_SG_ERR_SUGGEST_RETRY:
-                    print_str(" - Suggest Retry");
-                    break;
-                case OPENSEA_SG_ERR_SUGGEST_ABORT:
-                    print_str(" - Suggest Abort");
-                    break;
-                case OPENSEA_SG_ERR_SUGGEST_REMAP:
-                    print_str(" - Suggest Remap");
-                    break;
-                case OPENSEA_SG_ERR_SUGGEST_DIE:
-                    print_str(" - Suggest Die");
-                    break;
-                case OPENSEA_SG_ERR_SUGGEST_SENSE:
-                    print_str(" - Suggest Sense");
-                    break;
-                default:
-                    print_str(" - Unknown suggestion");
-                    break;
-                }
-                print_str("\n");
-            }
-
-            // driver-level failure
-            if (io_hdr.response_len == 0)
-            {
-                ret = OS_PASSTHROUGH_FAILURE;
-            }
-        }
-    }
-
-    scsiIoCtx->device->drive_info.lastCommandTimeNanoSeconds = get_Nano_Seconds(commandTimer);
+    set_tDevice_Last_Command_Completion_Time_NS(scsiIoCtx->device, get_Nano_Seconds(commandTimer));
 #    ifdef _DEBUG
     printf("<--%s (%d)\n", __FUNCTION__, ret);
 #    endif
@@ -3079,7 +3148,7 @@ static eReturnValues send_sg_io_v3(ScsiIoCtx* M_NONNULL scsiIoCtx)
     //  Start with zapping the io_hdr
     M_INITIALIZE_STRUCTURE(&io_hdr, sizeof(sg_io_hdr_t));
 
-    print_tDevice_Verbose_String(scsiIoCtx->device, VERBOSITY_BUFFERS, "Sending command with send_IO\n");
+    print_tDevice_Verbose_String(scsiIoCtx->device, VERBOSITY_BUFFERS, "Sending command with send_sg_io_v3\n");
 
     // Set up the io_hdr
     io_hdr.interface_id = 'S';
@@ -3245,8 +3314,12 @@ eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
         (scsiIoCtx->device->os_info.secondHandleValid &&
          is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.secondName)))
     {
-        // BSG handles: must use v4, SG_GET_VERSION_NUM doesn't apply
-        return send_sg_io_v4(scsiIoCtx);
+        // BSG handles: pre 4.18, v3, otherwise v4
+        if (scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&
+            scsiIoCtx->device->os_info.sgDriverVersion.majorVersion >= 4)
+            return send_sg_io_v4(scsiIoCtx);
+        else
+            return send_sg_io_v3(scsiIoCtx);
     }
     else if (is_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) &&
              scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -2175,11 +2175,10 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
     {
         if (is_Block_SCSI_Generic_Handle(deviceHandle))
         {
-            // BSG handle on pre-4.18: version check failed, but we'll use v3 SG_IO instead of v4
-            device->os_info.sgDriverVersion.driverVersionValid = true;
-            device->os_info.sgDriverVersion.majorVersion       = 3; // Default to v3 for BSG on older kernels
-            device->os_info.sgDriverVersion.minorVersion       = 0;
-            device->os_info.sgDriverVersion.revision           = 0;
+            // SG_GET_VERSION_NUM ioctl is not supported on /dev/bsg/* handles
+            // (they only exist on kernel 4.18+, where SGv4 is guaranteed available).
+            // This is expected behavior, not an error. Router will use v4 for BSG.
+            device->os_info.sgDriverVersion.driverVersionValid = false;
         }
         else
         {
@@ -3126,7 +3125,7 @@ static eReturnValues send_sg_io_v4(ScsiIoCtx* M_NONNULL scsiIoCtx)
     }
 
     // Parse sense data from response
-    if (io_hdr.response_len > 0)
+    if (io_hdr.response_len > 0 && io_hdr.response != 0)
     {
         uint8_t* responseBuf           = M_REINTERPRET_CAST(uint8_t*, C_CAST(uintptr_t, io_hdr.response));
         scsiIoCtx->returnStatus.format = responseBuf[0];
@@ -3327,8 +3326,20 @@ eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
         (scsiIoCtx->device->os_info.secondHandleValid &&
          is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.secondName)))
     {
-        // BSG handles: SEA_BSG_IOCTL_H guarantees kernel 4.18+ with v4 support
-        return send_sg_io_v4(scsiIoCtx);
+        // BSG handles: Check if v4 is ACTUALLY supported at runtime
+        // If SG_GET_VERSION_NUM failed (driverVersionValid=false), it might be v3 or not supported
+        // Conservative: if we can't verify support, fall back to v3
+        if (scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid)
+        {
+            // We got version info - BSG is compatible
+            return send_sg_io_v4(scsiIoCtx);
+        }
+        else
+        {
+            // SG_GET_VERSION_NUM failed - BSG support unclear at runtime
+            // Fall back to v3 (still might fail on very old kernels, but safer)
+            return send_sg_io_v3(scsiIoCtx);
+        }
     }
     else if (is_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) &&
              scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&

--- a/src/sg_helper.c
+++ b/src/sg_helper.c
@@ -301,7 +301,7 @@ typedef struct s_sysFSLowLevelDeviceInfo
     char     fullDevicePath[OPENSEA_PATH_MAX];
     char     primaryHandleStr[OS_HANDLE_NAME_MAX_LENGTH];      // dev/sg or /dev/nvmexny (namespace handle)
     char     secondaryHandleStr[OS_SECOND_HANDLE_NAME_LENGTH]; // dev/sd or /dev/nvmex (controller handle)
-    char     tertiaryHandleStr[OS_SECOND_HANDLE_NAME_LENGTH];  // dev/bsg or /dev/ngXnY (nvme generic handle)
+    char     tertiaryHandleStr[OS_THIRD_HANDLE_NAME_LENGTH];   // dev/bsg or /dev/ngXnY (nvme generic handle)
     uint16_t queueDepth;                                       // if 0, then this was unable to be read and populated
 } sysFSLowLevelDeviceInfo;
 
@@ -1306,11 +1306,11 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
             }
             if (is_Block_Device_Handle(handle))
             {
+                // incomingBlock = true;
                 if (0 != safe_strcat(incomingHandleClassPath, PATH_MAX, "block/"))
                 {
                     return;
                 }
-                // incomingBlock = true;
             }
             else if (is_Block_SCSI_Generic_Handle(handle))
             {
@@ -1392,20 +1392,28 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                         get_Linux_SYS_FS_SCSI_Device_File_Info(sysFsInfo);
 
                         char* baseLink = basename(inHandleLink);
-                        if (incomingBSG)
+                        if (incomingBSG) // set incoming bsg to tertiary
                         {
-                            if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
+                            if (snprintf_err_handle(sysFsInfo->tertiaryHandleStr, OS_THIRD_HANDLE_NAME_LENGTH,
                                                     "/dev/bsg/%s", baseLink) < 0)
                             {
                                 safe_free(&duphandle);
                                 return;
                             }
                         }
-                        else // for both sg and sd, set accordingly. We are setting the block handle also as primary
-                             // here, but change it later to the bsg or sg
+                        else if (incomingSG) // set incoming sg to primary
                         {
                             if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH, "/dev/%s",
                                                     baseLink) < 0)
+                            {
+                                safe_free(&duphandle);
+                                return;
+                            }
+                        }
+                        else // set incoming sd to secondary
+                        {
+                            if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
+                                                    "/dev/%s", baseLink) < 0)
                             {
                                 safe_free(&duphandle);
                                 return;
@@ -1446,9 +1454,9 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
 
                             if (incomingSG)
                             {
-                                if (bsgHandle != M_NULLPTR) // save secondary handle name as bsg handle
+                                if (bsgHandle != M_NULLPTR) // save tertiary handle name as bsg handle
                                 {
-                                    if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
+                                    if (snprintf_err_handle(sysFsInfo->tertiaryHandleStr, OS_THIRD_HANDLE_NAME_LENGTH,
                                                             "/dev/bsg/%s", bsgHandle) < 0)
                                     {
                                         safe_free(&blockHandle);
@@ -1458,7 +1466,7 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                                         return;
                                     }
                                 }
-                                else if (blockHandle != M_NULLPTR) // save secondary handle name as block handle
+                                if (blockHandle != M_NULLPTR) // save secondary handle name as block handle
                                 {
                                     if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
                                                             "/dev/%s", blockHandle) < 0)
@@ -1473,9 +1481,9 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                             }
                             else if (incomingBSG)
                             {
-                                if (genHandle != M_NULLPTR) // save secondary handle name as sg handle
+                                if (genHandle != M_NULLPTR) // save primary handle name as sg handle
                                 {
-                                    if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
+                                    if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
                                                             "/dev/%s", genHandle) < 0)
                                     {
                                         safe_free(&blockHandle);
@@ -1485,7 +1493,7 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                                         return;
                                     }
                                 }
-                                else if (blockHandle != M_NULLPTR) // save secondary handle name as block handle
+                                if (blockHandle != M_NULLPTR) // save secondary handle name as block handle
                                 {
                                     if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
                                                             "/dev/%s", blockHandle) < 0)
@@ -1500,9 +1508,9 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                             }
                             else // for block handle change the primary handle as well
                             {
-                                if (bsgHandle != M_NULLPTR) // save primary handle name as bsg handle
+                                if (bsgHandle != M_NULLPTR) // save tertiary handle name as bsg handle
                                 {
-                                    if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
+                                    if (snprintf_err_handle(sysFsInfo->tertiaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
                                                             "/dev/bsg/%s", bsgHandle) < 0)
                                     {
                                         safe_free(&blockHandle);
@@ -1512,24 +1520,10 @@ static void get_Linux_SYS_FS_Info(const char* handle, sysFSLowLevelDeviceInfo* s
                                         return;
                                     }
                                 }
-                                else if (genHandle != M_NULLPTR) // save primary handle name as sg handle
+                                if (genHandle != M_NULLPTR) // save primary handle name as sg handle
                                 {
                                     if (snprintf_err_handle(sysFsInfo->primaryHandleStr, OS_HANDLE_NAME_MAX_LENGTH,
                                                             "/dev/%s", genHandle) < 0)
-                                    {
-                                        safe_free(&blockHandle);
-                                        safe_free(&genHandle);
-                                        safe_free(&bsgHandle);
-                                        safe_free(&duphandle);
-                                        return;
-                                    }
-                                }
-
-                                // set block handle as secondary handle
-                                if (blockHandle != M_NULLPTR)
-                                {
-                                    if (snprintf_err_handle(sysFsInfo->secondaryHandleStr, OS_SECOND_HANDLE_NAME_LENGTH,
-                                                            "/dev/%s", blockHandle) < 0)
                                     {
                                         safe_free(&blockHandle);
                                         safe_free(&genHandle);
@@ -1598,7 +1592,8 @@ static void set_Device_Fields_From_Handle(const char* M_NONNULL handle, tDevice*
             safe_memcpy(&device->drive_info.driver_info, sizeof(driverInfo), &sysFsInfo.driver_info,
                         sizeof(driverInfo)),
             "Using exact same internal structure definition of driverInfo so this should never fail");
-        if (safe_strlen(sysFsInfo.primaryHandleStr) > 0)
+        if (safe_strlen(sysFsInfo.primaryHandleStr) >
+            0) // This means we were able to get sg handle, either incoming or mapped through bsg or sd handle
         {
             char* dupHandle = M_NULLPTR;
             if (0 != safe_strdup(&dupHandle, sysFsInfo.primaryHandleStr) || dupHandle == M_NULLPTR)
@@ -1610,6 +1605,23 @@ static void set_Device_Fields_From_Handle(const char* M_NONNULL handle, tDevice*
                 set_Device_Name_In_tDevice(device, sysFsInfo.primaryHandleStr, basename(dupHandle));
             }
             safe_free(&dupHandle);
+        }
+        else // This is when the incoming handle was bsg or sd, and we were not able to map sg handle, in this case
+             // fallback to set sd handle to primary name
+        {
+            if (safe_strlen(sysFsInfo.secondaryHandleStr) > 0) // if we get sd handle
+            {
+                char* dupHandle = M_NULLPTR;
+                if (0 != safe_strdup(&dupHandle, sysFsInfo.secondaryHandleStr) || dupHandle == M_NULLPTR)
+                {
+                    set_Device_Name_In_tDevice(device, sysFsInfo.secondaryHandleStr, M_NULLPTR);
+                }
+                else
+                {
+                    set_Device_Name_In_tDevice(device, sysFsInfo.secondaryHandleStr, basename(dupHandle));
+                }
+                safe_free(&dupHandle);
+            }
         }
         if (safe_strlen(sysFsInfo.secondaryHandleStr) > 0)
         {
@@ -1624,6 +1636,20 @@ static void set_Device_Fields_From_Handle(const char* M_NONNULL handle, tDevice*
             }
             safe_free(&dupSecond);
             device->os_info.secondHandleValid = true;
+        }
+        if (safe_strlen(sysFsInfo.tertiaryHandleStr) > 0)
+        {
+            char* dupThird = M_NULLPTR;
+            if (0 != safe_strdup(&dupThird, sysFsInfo.tertiaryHandleStr) || dupThird == M_NULLPTR)
+            {
+                set_Third_Device_Name_In_tDevice(device, sysFsInfo.tertiaryHandleStr, M_NULLPTR);
+            }
+            else
+            {
+                set_Third_Device_Name_In_tDevice(device, sysFsInfo.tertiaryHandleStr, basename(dupThird));
+            }
+            safe_free(&dupThird);
+            device->os_info.thirdHandleValid = true;
         }
 
         // Copy HCTL (Host:Channel:Target:LUN) from sysfs if available
@@ -1962,7 +1988,8 @@ M_PARAM_RW(1)
 static eReturnValues open_fd2(tDevice* M_NONNULL device)
 {
     eReturnValues ret = SUCCESS;
-    if (device->os_info.secondHandleValid && !device->os_info.secondHandleOpened)
+    if (device->os_info.secondHandleValid && is_Block_Device_Handle(device->os_info.secondName) &&
+        is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) && !device->os_info.fd2Opened)
     {
         char*             deviceHandle = M_NULLPTR;
         ePosixHandleFlags handleFlags  = POSIX_HANDLE_FLAGS_DEFAULT;
@@ -1991,7 +2018,7 @@ static eReturnValues open_fd2(tDevice* M_NONNULL device)
         free_Posix_Resolved_Filename(&deviceHandle);
         if (device->os_info.fd2 > 0)
         {
-            device->os_info.secondHandleOpened = true;
+            device->os_info.fd2Opened = true;
         }
         else
         {
@@ -2001,6 +2028,55 @@ static eReturnValues open_fd2(tDevice* M_NONNULL device)
     return ret;
 }
 
+// This is used to open device->os_info.fd3 which is where we will store
+// a /dev/sg handle which is a sg handle for SCSI devices.
+// This is case where we have opened the device->os_info.fd as bsg handle and we can't send
+// SG_RESET_* commands on bsg handles
+M_PARAM_RW(1)
+static eReturnValues open_fd3(tDevice* M_NONNULL device)
+{
+    eReturnValues ret = SUCCESS;
+    if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+        is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) &&
+        !device->os_info.fd3Opened) // Ex. fd = /dev/bsg, and primary name is /dev/sg --> we need
+                                    // fd3 to send sg_reset commands
+    {
+        char*             deviceHandle = M_NULLPTR;
+        ePosixHandleFlags handleFlags  = POSIX_HANDLE_FLAGS_DEFAULT;
+        ret                            = posix_Resolve_Filename_Link(get_Device_Handle_Name(device), &deviceHandle);
+        if (ret != SUCCESS)
+        {
+            free_Posix_Resolved_Filename(&deviceHandle);
+            return ret;
+        }
+
+        if (device->dFlags & HANDLE_REQUIRE_EXCLUSIVE_ACCESS)
+        {
+            handleFlags = POSIX_HANDLE_FLAGS_REQUIRE_EXCLUSIVE;
+        }
+        else if (device->dFlags & HANDLE_RECOMMEND_EXCLUSIVE_ACCESS)
+        {
+            handleFlags = POSIX_HANDLE_FLAGS_REQUEST_EXCLUSIVE;
+        }
+
+        ret = posix_Get_Device_Handle(deviceHandle, &device->os_info.fd3, &handleFlags, 0);
+        if (ret != SUCCESS)
+        {
+            free_Posix_Resolved_Filename(&deviceHandle);
+            return ret;
+        }
+        free_Posix_Resolved_Filename(&deviceHandle);
+        if (device->os_info.fd3 > 0)
+        {
+            device->os_info.fd3Opened = true;
+        }
+        else
+        {
+            ret = FAILURE;
+        }
+    }
+    return ret;
+}
 #define LIN_MAX_HANDLE_LENGTH 30
 static eReturnValues resolve_Block_Handle_To_Generic_Handle(const char* filename, char** genericHandle)
 {
@@ -2139,7 +2215,7 @@ static eReturnValues linux_Get_NVMe_Device(tDevice* M_NONNULL device, const char
 #endif     // DISABLE_NVME_PASSTHROUGH
 }
 
-static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char* deviceHandle)
+static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char* genericHandle, const char* fileName)
 {
     int k = 0;
 #if defined(_DEBUG)
@@ -2173,7 +2249,7 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
     // From http://tldp.org/HOWTO/SCSI-Generic-HOWTO/pexample.html
     if ((ioctl(device->os_info.fd, SG_GET_VERSION_NUM, &k) < 0) || (k < 30000))
     {
-        if (is_Block_SCSI_Generic_Handle(deviceHandle))
+        if (is_Block_SCSI_Generic_Handle(genericHandle))
         {
             // SG_GET_VERSION_NUM ioctl is not supported on /dev/bsg/* handles
             // (they only exist on kernel 4.18+, where SGv4 is guaranteed available).
@@ -2182,7 +2258,8 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
         }
         else
         {
-            printf("%s: SG_GET_VERSION_NUM on %s failed version=%d\n", __FUNCTION__, deviceHandle, k);
+            printf("%s: SG_GET_VERSION_NUM on %s (opened as %s) failed version=%d\n", __FUNCTION__, fileName,
+                   genericHandle, k);
             perror("SG_GET_VERSION_NUM");
             close(device->os_info.fd);
             return FAILURE;
@@ -2208,12 +2285,13 @@ static eReturnValues linux_Get_SCSI_Device(tDevice* M_NONNULL device, const char
 #if defined(_DEBUG)
     print_str("Setting interface, drive type, secondary handles\n");
 #endif
-    set_Device_Fields_From_Handle(deviceHandle, device);
+    set_Device_Fields_From_Handle(fileName, device);
     setup_Passthrough_Hacks_By_ID(device);
 
 #if defined(_DEBUG)
-    printf("name = %s\t friendly name = %s\n2ndName = %s\t2ndFName = %s\n", get_Device_Handle_Name(device),
-           get_Device_Handle_Friendly_Name(device), device->os_info.secondName, device->os_info.secondFriendlyName);
+    printf("name = %s\t friendly name = %s\n2ndName = %s\t2ndFName = %s\n3rdName = %s\t3rdFName = %s\n",
+           get_Device_Handle_Name(device), get_Device_Handle_Friendly_Name(device), device->os_info.secondName,
+           device->os_info.secondFriendlyName, device->os_info.thirdName, device->os_info.thirdFriendlyName);
     printf("h:c:t:l = %u:%u:%u:%u\n", device->os_info.scsiAddress.host, device->os_info.scsiAddress.channel,
            device->os_info.scsiAddress.target, device->os_info.scsiAddress.lun);
 
@@ -2309,7 +2387,7 @@ static eReturnValues get_Lin_Device(const char* filename, tDevice* M_NONNULL dev
         }
         else // not an NVMe handle
         {
-            ret = linux_Get_SCSI_Device(device, filename);
+            ret = linux_Get_SCSI_Device(device, genericHandle, filename);
         }
         if (ret == SUCCESS)
         {
@@ -2387,17 +2465,65 @@ static eReturnValues sg_reset(int fd, int resetType)
 
 OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Device_Reset(const tDevice* M_NONNULL device)
 {
-    return sg_reset(device->os_info.fd, SG_SCSI_RESET_DEVICE);
+    int* fdToRescan = M_CONST_CAST(int*, &device->os_info.fd);
+    // If 3rd name is valid, meaning we have opened the BSG handle, and we can't call SG_SCSI_RESET
+    // Fallback is to open sg handle, which could be opened via primary name
+    if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+        is_SCSI_Generic_Handle(get_Device_Handle_Name(device)))
+    {
+        // First open the handle
+        if (SUCCESS == open_fd3(M_CONST_CAST(tDevice*, device)))
+        {
+#if defined(_DEBUG)
+            printf("using fd3: %s\n", get_Device_Handle_Name(device));
+#endif
+            fdToRescan = M_CONST_CAST(int*, &device->os_info.fd3);
+        }
+    }
+
+    return sg_reset(*fdToRescan, SG_SCSI_RESET_DEVICE);
 }
 
 OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Bus_Reset(const tDevice* M_NONNULL device)
 {
-    return sg_reset(device->os_info.fd, SG_SCSI_RESET_BUS);
+    int* fdToRescan = M_CONST_CAST(int*, &device->os_info.fd);
+    // If 3rd name is valid, meaning we have opened the BSG handle, and we can't call SG_SCSI_RESET
+    // Fallback is to open sg handle, which could be opened via primary name
+    if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+        is_SCSI_Generic_Handle(get_Device_Handle_Name(device)))
+    {
+        // First open the handle
+        if (SUCCESS == open_fd3(M_CONST_CAST(tDevice*, device)))
+        {
+#if defined(_DEBUG)
+            printf("using fd3: %s\n", get_Device_Handle_Name(device));
+#endif
+            fdToRescan = M_CONST_CAST(int*, &device->os_info.fd3);
+        }
+    }
+
+    return sg_reset(*fdToRescan, SG_SCSI_RESET_BUS);
 }
 
 OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Controller_Reset(const tDevice* M_NONNULL device)
 {
-    return sg_reset(device->os_info.fd, SG_SCSI_RESET_HOST);
+    int* fdToRescan = M_CONST_CAST(int*, &device->os_info.fd);
+    // If 3rd name is valid, meaning we have opened the BSG handle, and we can't call SG_SCSI_RESET
+    // Fallback is to open sg handle, which could be opened via primary name
+    if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+        is_SCSI_Generic_Handle(get_Device_Handle_Name(device)))
+    {
+        // First open the handle
+        if (SUCCESS == open_fd3(M_CONST_CAST(tDevice*, device)))
+        {
+#if defined(_DEBUG)
+            printf("using fd3: %s\n", get_Device_Handle_Name(device));
+#endif
+            fdToRescan = M_CONST_CAST(int*, &device->os_info.fd3);
+        }
+    }
+
+    return sg_reset(*fdToRescan, SG_SCSI_RESET_HOST);
 }
 
 M_PARAM_RO(1) eReturnValues send_IO(ScsiIoCtx* M_NONNULL scsiIoCtx)
@@ -3322,24 +3448,11 @@ static eReturnValues send_sg_io_v3(ScsiIoCtx* M_NONNULL scsiIoCtx)
 eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
 {
 #if defined(SEA_BSG_IOCTL_H)
-    if (is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) ||
-        (scsiIoCtx->device->os_info.secondHandleValid &&
-         is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.secondName)))
+    if (scsiIoCtx->device->os_info.thirdHandleValid &&
+        is_Block_SCSI_Generic_Handle(scsiIoCtx->device->os_info.thirdName))
     {
-        // BSG handles: Check if v4 is ACTUALLY supported at runtime
-        // If SG_GET_VERSION_NUM failed (driverVersionValid=false), it might be v3 or not supported
-        // Conservative: if we can't verify support, fall back to v3
-        if (scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid)
-        {
-            // We got version info - BSG is compatible
-            return send_sg_io_v4(scsiIoCtx);
-        }
-        else
-        {
-            // SG_GET_VERSION_NUM failed - BSG support unclear at runtime
-            // Fall back to v3 (still might fail on very old kernels, but safer)
-            return send_sg_io_v3(scsiIoCtx);
-        }
+        // BSG always use v4 version
+        return send_sg_io_v4(scsiIoCtx);
     }
     else if (is_SCSI_Generic_Handle(scsiIoCtx->device->os_info.name) &&
              scsiIoCtx->device->os_info.sgDriverVersion.driverVersionValid &&
@@ -3351,7 +3464,7 @@ eReturnValues send_sg_io(ScsiIoCtx* scsiIoCtx)
     else
 #endif
     {
-        // SG driver 3.x on /dev/sg*, pre-4.18 BSG, or /dev/sd* block handles: use v3
+        // SG driver 3.x on /dev/sg*, or /dev/sd* block handles: use v3
         return send_sg_io_v3(scsiIoCtx);
     }
 }
@@ -3906,11 +4019,21 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues close_Device(tDevice* dev)
             retValue                = close(dev->os_info.fd);
             dev->os_info.last_error = errno;
 
-            if (dev->os_info.secondHandleValid && dev->os_info.secondHandleOpened)
+            if (dev->os_info.secondHandleValid && is_Block_Device_Handle(dev->os_info.secondName) &&
+                is_SCSI_Generic_Handle(get_Device_Handle_Name(dev)) && dev->os_info.fd2Opened)
             {
                 if (close(dev->os_info.fd2) == 0)
                 {
                     dev->os_info.fd2 = -1;
+                }
+            }
+
+            if (dev->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(dev->os_info.thirdName) &&
+                is_SCSI_Generic_Handle(get_Device_Handle_Name(dev)) && dev->os_info.fd3Opened)
+            {
+                if (close(dev->os_info.fd3) == 0)
+                {
+                    dev->os_info.fd3 = -1;
                 }
             }
         }
@@ -4527,15 +4650,27 @@ OPENSEA_TRANSPORT_API M_PARAM_RW(1) eReturnValues os_Get_Exclusive(tDevice* M_NO
             }
             ++attempts;
         } while (attempts < EXCL_ATTEMPT_MAX);
-        if (device->os_info.secondHandleValid)
+        if (device->os_info.secondHandleValid && is_Block_Device_Handle(device->os_info.secondName) &&
+            is_SCSI_Generic_Handle(get_Device_Handle_Name(device)))
         {
-            if (device->os_info.secondHandleOpened)
+            if (device->os_info.fd2Opened)
             {
                 close(device->os_info.fd2);
-                device->os_info.secondHandleOpened = false;
+                device->os_info.fd2Opened = false;
             }
             device->dFlags |= HANDLE_RECOMMEND_EXCLUSIVE_ACCESS;
             open_fd2(device);
+        }
+        if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+            is_SCSI_Generic_Handle(get_Device_Handle_Name(device)))
+        {
+            if (device->os_info.fd3Opened)
+            {
+                close(device->os_info.fd3);
+                device->os_info.fd3Opened = false;
+            }
+            device->dFlags |= HANDLE_RECOMMEND_EXCLUSIVE_ACCESS;
+            open_fd3(device);
         }
     }
     return ret;
@@ -4550,9 +4685,15 @@ OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Lock_Device(const tDevice* 
         {
             ret = FAILURE;
         }
-        if (device->os_info.secondHandleValid && device->os_info.secondHandleOpened)
+        if (device->os_info.secondHandleValid && is_Block_Device_Handle(device->os_info.secondName) &&
+            is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) && device->os_info.fd2Opened)
         {
             lock_unlock_handle(device, device->os_info.fd2, true);
+        }
+        if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+            is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) && device->os_info.fd3Opened)
+        {
+            lock_unlock_handle(device, device->os_info.fd3, true);
         }
     }
     if (ret == SUCCESS && device->os_info.lockCount < UINT16_MAX)
@@ -4573,9 +4714,15 @@ OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Unlock_Device(const tDevice
         {
             ret = FAILURE;
         }
-        if (device->os_info.secondHandleValid && device->os_info.secondHandleOpened)
+        if (device->os_info.secondHandleValid && is_Block_Device_Handle(device->os_info.secondName) &&
+            is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) && device->os_info.fd2Opened)
         {
             lock_unlock_handle(device, device->os_info.fd2, false);
+        }
+        if (device->os_info.thirdHandleValid && is_Block_SCSI_Generic_Handle(device->os_info.thirdName) &&
+            is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) && device->os_info.fd3Opened)
+        {
+            lock_unlock_handle(device, device->os_info.fd3, true);
         }
     }
     if (ret == SUCCESS && device->os_info.lockCount > 0)
@@ -4592,7 +4739,8 @@ OPENSEA_TRANSPORT_API M_PARAM_RO(1) eReturnValues os_Update_File_System_Cache(co
 #if defined(_DEBUG)
     print_str("Updating file system cache\n");
 #endif
-    if (device->os_info.secondHandleValid && SUCCESS == open_fd2(M_CONST_CAST(tDevice*, device)))
+    if (device->os_info.secondHandleValid && is_Block_Device_Handle(device->os_info.secondName) &&
+        is_SCSI_Generic_Handle(get_Device_Handle_Name(device)) && SUCCESS == open_fd2(M_CONST_CAST(tDevice*, device)))
     {
 #if defined(_DEBUG)
         printf("using fd2: %s\n", device->os_info.secondName);

--- a/src/vm_helper.c
+++ b/src/vm_helper.c
@@ -146,7 +146,7 @@ typedef struct s_sysVMLowLevelDeviceInfo
     char     fullDevicePath[OPENSEA_PATH_MAX];
     char     primaryHandleStr[OS_HANDLE_NAME_MAX_LENGTH];      // dev/sg or /dev/nvmexny (namespace handle)
     char     secondaryHandleStr[OS_SECOND_HANDLE_NAME_LENGTH]; // dev/sd or /dev/nvmex (controller handle)
-    char     tertiaryHandleStr[OS_SECOND_HANDLE_NAME_LENGTH];  // dev/bsg or /dev/ngXnY (nvme generic handle)
+    char     tertiaryHandleStr[OS_THIRD_HANDLE_NAME_LENGTH];   // dev/bsg or /dev/ngXnY (nvme generic handle)
     uint16_t queueDepth;                                       // if 0, then this was unable to be read and populated
 } sysVMLowLevelDeviceInfo;
 


### PR DESCRIPTION
# Add SG v4 (SCSI Generic) Interface Support

## Summary
Implements full support for the SG v4 (SCSI Generic v4) interface available in Linux kernel 4.18+, enabling direct use of advanced v4 features such as bidirectional data transfers and improved protocol handling for BSG (Block SCSI Generic) devices.

## Changes

### 1. New File: `include/sg_io_v4.h`
Complete struct definition for `sg_io_v4` interface including:
- Input fields: guard, protocol, subprotocol, request buffer, response buffer capacity
- Data transfer fields: din_xferp, dout_xferp with lengths for both directions
- Timeout configuration in milliseconds
- Output fields: device_status, transport_status, driver_status, response_len, sense data residuals
- All associated SG v4 protocol constants and flags

### 2. New Function: `send_sg_io_v4()` in `src/sg_helper.c`
Full implementation of SG v4 ioctl passthrough:
- Initializes v4 struct with proper guard value ('Q')
- Configures protocol (BSG_PROTOCOL_SCSI) and subprotocol (BSG_SUB_PROTOCOL_SCSI_CMD)
- Sets up request/response buffer pointers and sizes
- Supports all data transfer directions:
  - `XFER_NO_DATA` - no data transfer
  - `XFER_DATA_IN` - device to host
  - `XFER_DATA_OUT` - host to device
  - `XFER_DATA_IN_OUT` / `XFER_DATA_OUT_IN` - bidirectional transfers (v4-specific feature)
- Handles device timeout with proper millisecond conversion
- Parses response data including sense key, ASC, ASCQ, and FRU code
- Extracts device, transport, and driver status from v4 output fields

### 3. Updated Routing Logic in `send_sg_io()`
Intelligent command routing based on device type and capability:
- **BSG Handles** (`/dev/bsg*`): Routes to `send_sg_io_v4()` when v4 support available
- **SG Driver v4+** (`/dev/sg*` with driver version ≥4): Routes to `send_sg_io_v4()` for advanced features
- **SG Driver v3** (`/dev/sg*` with driver version <4): Routes to existing `send_sg_io_v3()`
- **Block Devices** (`/dev/sd*`): Uses `send_sg_io_v3()` for compatibility

## Key Features Added

- **Bidirectional Data Transfer:** Full support for simultaneous read and write operations in single command
- **Enhanced Status Reporting:** Separate device, transport, and driver status fields
- **Improved Response Handling:** Proper response_len tracking for sense data and status information
- **Automatic Capability Detection:** Runtime selection of v4 vs v3 based on actual device capabilities
- **Backward Compatibility:** Existing v3 code path unchanged; v3 devices continue to work identically

## Device Support

| Device Type | Driver Version | Interface | Implementation |
|---|---|---|---|
| /dev/bsg* | N/A | BSG v4 | send_sg_io_v4() |
| /dev/sg* | 4.x+ | SG v4 | send_sg_io_v4() |
| /dev/sg* | 3.x | SG v3 | send_sg_io_v3() |
| /dev/sd* | Any | Block | send_sg_io_v3() |