### PR TITLE
feature: Support NVMe drives behind Realtek USB bridges

### DIFF
--- a/include/common_public.h
+++ b/include/common_public.h
@@ -1270,9 +1270,12 @@ extern "C"
             bool possilbyEmulatedNVMe; // realtek's USB to M.2 adapter can do AHCI or NVMe. Since nothing changes in IDs
                                        // and it emulates ATA identify data, need this to work around how it reports.
                                        // -TJE
-            bool smartEnabled;         // Override check of ATA word 85, bit0 since some USB adapters don't set this.
-            bool retryWithJMicronPT;   // Needed for some JMicron adapters. Newer may support SAT, older support their
-                                       // lagacy passthrough, so this is to retry on these devices.
+            bool knownRealtekUSB; // Set for bridges identified as a Realtek USB to NVMe/SATA adapter (by VID/PID or the
+                                  // ATA path RTL9210 heuristic). Separate from possilbyEmulatedNVMe because branded
+                                  // adapters (e.g. Seagate) also set that flag and still need SAT.
+            bool smartEnabled;    // Override check of ATA word 85, bit0 since some USB adapters don't set this.
+            bool retryWithJMicronPT; // Needed for some JMicron adapters. Newer may support SAT, older support their
+                                     // lagacy passthrough, so this is to retry on these devices.
             bool jmPTDevSet; // for JMicron's passthrough we need to set dev 0 or 1. This gets turned to true once set
             bool nonDataCountBroken;  // Implemented due to Broadcom HBA firmware bug. When issuing a non-data command
                                       // with non-zero count, it zeroes it to the drive. So this creates unexpected

--- a/include/common_public.h
+++ b/include/common_public.h
@@ -2687,6 +2687,34 @@ typedef errno_t lasterror_t; // errno in POSIX OSs
     //-----------------------------------------------------------------------------
     OPENSEA_TRANSPORT_API void scan_And_Print_Devs(unsigned int flags, eVerbosityLevels scanVerbosity);
 
+    //-----------------------------------------------------------------------------
+    //
+    //  get_Device_Strings_For_Display()
+    //
+    //! \brief   Description:  Returns the model, serial number, and firmware revision strings to use for display.
+    //!                        When a drive is behind a USB/SAT bridge, the standard drive info fields hold the bridge's
+    //!                        SCSI identity while the actual drive's identity is stored in the bridge info (child
+    //!                        MN/SN/FW). The child drive identity is preferred when it is available.
+    //!
+    //  Entry:
+    //!   \param[in] device = the device to get the strings for
+    //!   \param[out] modelString = pointer to a const char* to receive the model number string
+    //!   \param[out] serialString = pointer to a const char* to receive the serial number string
+    //!   \param[out] fwString = pointer to a const char* to receive the firmware revision string
+    //!
+    //  Exit:
+    //!   \return void
+    //
+    //-----------------------------------------------------------------------------
+    M_PARAM_RO(1)
+    M_PARAM_RW(2)
+    M_PARAM_RW(3)
+    M_PARAM_RW(4)
+    OPENSEA_TRANSPORT_API void get_Device_Strings_For_Display(const tDevice* M_NONNULL device,
+                                                              const char** M_NONNULL   modelString,
+                                                              const char** M_NONNULL   serialString,
+                                                              const char** M_NONNULL   fwString);
+
 #define SCAN_DISPLAY_HANDLE_STRING_LENGTH 256
     typedef struct s_scanDriveInfo
     {

--- a/src/ata_helper.c
+++ b/src/ata_helper.c
@@ -3242,6 +3242,7 @@ OPENSEA_TRANSPORT_API eReturnValues fill_In_ATA_Drive_Info(tDevice* M_NONNULL de
             print_tDevice_Verbose_String(device, VERBOSITY_DEFAULT,
                                          "         this may cause adverse behavior and require --forceSCSI\n");
             device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe = true;
+            device->drive_info.passThroughHacks.ataPTHacks.knownRealtekUSB      = true;
         }
 
         if (get_Device_InterfaceType(device) == SCSI_INTERFACE)

--- a/src/common_public.c
+++ b/src/common_public.c
@@ -6109,6 +6109,8 @@ static bool set_Realtek_USB_Hacks_By_PID(tDevice* M_NONNULL device)
         device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe =
             true; // no way to tell at this point. Will need to make full determination in the fill_ATA_Info
                   // function
+        device->drive_info.passThroughHacks.ataPTHacks.knownRealtekUSB =
+            true; // this is an actual Realtek bridge, so the Realtek NVMe passthrough discovery is safe to try
         device->drive_info.passThroughHacks.ataPTHacks.noMultipleModeCommands =
             true; // probably not needed, but after what I saw testing this, it can't hurt to set this
         break;

--- a/src/common_public.c
+++ b/src/common_public.c
@@ -1296,6 +1296,35 @@ OPENSEA_TRANSPORT_API void scan_And_Print_Devs(unsigned int flags, eVerbosityLev
     safe_free(C_CAST(void**, &scanDeviceList));
 }
 
+// When a drive is behind a USB/SAT bridge, the standard drive info fields hold the bridge's SCSI identity while the
+// actual drive's identity is stored in the bridge info (child MN/SN/FW). This returns the identity strings for
+// display purposes, preferring the child drive identity when it is available.
+M_PARAM_RO(1)
+M_PARAM_RW(2)
+M_PARAM_RW(3)
+M_PARAM_RW(4)
+OPENSEA_TRANSPORT_API void get_Device_Strings_For_Display(const tDevice* M_NONNULL device,
+                                                          const char** M_NONNULL   modelString,
+                                                          const char** M_NONNULL   serialString,
+                                                          const char** M_NONNULL   fwString)
+{
+    *modelString  = device->drive_info.product_identification;
+    *serialString = device->drive_info.serialNumber;
+    *fwString     = device->drive_info.product_revision;
+    if (device->drive_info.bridge_info.isValid && device->drive_info.bridge_info.childDriveMN[0] != '\0')
+    {
+        *modelString = device->drive_info.bridge_info.childDriveMN;
+        if (device->drive_info.bridge_info.childDriveSN[0] != '\0')
+        {
+            *serialString = device->drive_info.bridge_info.childDriveSN;
+        }
+        if (device->drive_info.bridge_info.childDriveFW[0] != '\0')
+        {
+            *fwString = device->drive_info.bridge_info.childDriveFW;
+        }
+    }
+}
+
 M_PARAM_RW(3)
 M_PARAM_RW(4)
 OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int        flags,
@@ -1465,9 +1494,18 @@ OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int    
                         }
 #endif
 
+                        // When a drive is behind a USB/SAT bridge, the standard drive info fields hold the bridge's
+                        // SCSI identity while the actual drive's identity is stored in the bridge info (child
+                        // MN/SN/FW). Prefer the child drive identity when it is available so the scan shows the real
+                        // drive.
+                        const char* modelString  = M_NULLPTR;
+                        const char* serialString = M_NULLPTR;
+                        const char* fwString     = M_NULLPTR;
+                        get_Device_Strings_For_Display(&deviceList[devIter], &modelString, &serialString, &fwString);
+
                         // model number
                         if (0 != safe_strcpy((*scanDeviceList)[deviceCountToBeShown].modelNumber, MODEL_NUM_LEN + 1,
-                                             deviceList[devIter].drive_info.product_identification))
+                                             modelString))
                             M_UNLIKELY
                             {
                                 perror("Error coping drive data for scan output");
@@ -1475,7 +1513,7 @@ OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int    
 
                         // serial number
                         if (0 != safe_strcpy((*scanDeviceList)[deviceCountToBeShown].serialNumber, SERIAL_NUM_LEN + 1,
-                                             deviceList[devIter].drive_info.serialNumber))
+                                             serialString))
                             M_UNLIKELY
                             {
                                 perror("Error coping drive data for scan output");
@@ -1496,7 +1534,7 @@ OPENSEA_TRANSPORT_API eReturnValues get_Devs_For_Scan_And_Print(unsigned int    
 
                         // firmware version
                         if (0 != safe_strcpy((*scanDeviceList)[deviceCountToBeShown].firmwareVersion, FW_REV_LEN + 1,
-                                             deviceList[devIter].drive_info.product_revision))
+                                             fwString))
                             M_UNLIKELY
                             {
                                 perror("Error coping drive data for scan output");

--- a/src/nvme_helper.c
+++ b/src/nvme_helper.c
@@ -70,6 +70,14 @@ M_PARAM_RW(1) eReturnValues fill_In_NVMe_Device_Info(tDevice* device)
 {
     eReturnValues ret = UNKNOWN;
 
+    // USB bridges generally do not report a namespace ID, so namespace-specific commands (e.g. Identify Namespace)
+    // would be sent with an NSID of 0 and fail with Invalid Namespace or Format. NVMe namespaces are 1-based, so
+    // default to namespace 1 for these devices.
+    if (device->drive_info.namespaceID == 0)
+    {
+        device->drive_info.namespaceID = 1;
+    }
+
     // set some pointers to where we want to fill in information...we're doing this so that on USB, we can store some
     // info about the child drive, without disrupting the standard drive_info that has already been filled in by the
     // fill_SCSI_Info function

--- a/src/realtek_nvme_helper.c
+++ b/src/realtek_nvme_helper.c
@@ -251,7 +251,8 @@ M_PARAM_RW(1) eReturnValues send_Realtek_NVMe_Cmd(nvmeCmdCtx* M_NONNULL nvmCmd)
         M_INITIALIZE_STRUCTURE(realtekPayload, REALTEK_NVME_CMD_PAYLOAD_LEN);
         ret = build_Realtek_NVMe_CDB_And_Payload(realtekCDB, &realtekCDBDir, realtekPayload,
                                                  REALTEK_NVME_COMPLETION_PAYLOAD_LEN, REALTEK_PHASE_COMPLETION, nvmCmd);
-        if (SUCCESS == scsi_Send_Cdb(nvmCmd->device, realtekCDB, REALTEK_NVME_CDB_SIZE, realtekPayload,
+        if (SUCCESS == ret &&
+            SUCCESS == scsi_Send_Cdb(nvmCmd->device, realtekCDB, REALTEK_NVME_CDB_SIZE, realtekPayload,
                                      REALTEK_NVME_COMPLETION_PAYLOAD_LEN, realtekCDBDir, NULL, 0, 15))
         {
             nvmCmd->commandCompletionData.dw0Valid = true;
@@ -270,7 +271,9 @@ M_PARAM_RW(1) eReturnValues send_Realtek_NVMe_Cmd(nvmeCmdCtx* M_NONNULL nvmCmd)
                 M_BytesTo4ByteValue(realtekPayload[15], realtekPayload[14], realtekPayload[13], realtekPayload[12]);
         }
     }
-    return ret;
+    // Return the result of the data transfer phase. The completion phase read is only used to fill in the NVMe
+    // completion DWords for debugging and must not mask the actual command result.
+    return sendRet;
 }
 
 // cmds supported:

--- a/src/scsi_helper.c
+++ b/src/scsi_helper.c
@@ -3787,7 +3787,10 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                 safe_free_aligned(&deviceIdentification);
             }
             // One last thing...Need to do a SAT scan...
-            if (checkForSAT)
+            // NOTE: Skip the SAT compliance check for bridges that may have an NVMe drive behind them (e.g. Realtek
+            // RTL9210). SAT ATA identify is not reliable on these adapters and can take a long time to time out, and
+            // the NVMe passthrough discovery below handles these devices correctly.
+            if (checkForSAT && !device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe)
             {
                 if (SUCCESS != check_SAT_Compliance_And_Set_Drive_Type(device) && checkJMicronNVMe)
                 {
@@ -3818,8 +3821,13 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                     }
                 }
             }
-            safe_free_aligned(&inq_buf);
-            return ret;
+            if (!device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe)
+            {
+                safe_free_aligned(&inq_buf);
+                return ret;
+            }
+            // This bridge may have an NVMe drive behind it (e.g. Realtek RTL9210). Do not quit discovery early here so
+            // that the NVMe passthrough discovery below can run and correctly identify the drive in a fast scan.
         }
 
         if (device->drive_info.scsiVersion > SCSI_VERSION_SCSI2 && get_Device_InterfaceType(device) != USB_INTERFACE &&
@@ -4251,23 +4259,23 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
         eReturnValues satCheck = FAILURE;
         // if we haven't already, check the device for SAT support. Allow this to run on IDE interface since we'll just
         // issue a SAT identify in here to set things up...might reduce multiple commands later
+        // Skip this for bridges that are known to possibly be emulating an NVMe drive (e.g. Realtek RTL9210) since they
+        // do not reliably support SCSI-ATA passthrough. On some firmware revisions the SAT identify can take a very
+        // long time to fail with an internal adapter error, or never return at all. The NVMe passthrough identify is
+        // attempted below in that case instead.
         if (checkForSAT && !satVPDPageRead && !satComplianceChecked && (get_Device_DriveType(device) != RAID_DRIVE) &&
             (get_Device_DriveType(device) != NVME_DRIVE) && get_Device_MediaType(device) != MEDIA_UNKNOWN &&
-            device->drive_info.passThroughHacks.passthroughType < NVME_PASSTHROUGH_JMICRON)
+            device->drive_info.passThroughHacks.passthroughType < NVME_PASSTHROUGH_JMICRON &&
+            !device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe)
         {
             satCheck = check_SAT_Compliance_And_Set_Drive_Type(device);
         }
 
-        bool checkRealtekNVMe = false;
-        if (satCheck == SUCCESS && return_Device_Child_MaxLba(device) == 0 &&
-            safe_strlen(device->drive_info.bridge_info.childDriveMN) &&
-            safe_strlen(device->drive_info.bridge_info.childDriveSN) &&
-            safe_strlen(device->drive_info.bridge_info.childDriveFW) &&
-            device->drive_info.passThroughHacks.ataPTHacks
-                .possilbyEmulatedNVMe) // This can be set by the ata_helper in SAT check now, so check it here.
-        {
-            checkRealtekNVMe = true;
-        }
+        // This flag is set for bridges that are known to possibly have an NVMe drive behind them (Realtek RTL9210),
+        // either by reported VID/PID or inquiry data, or by the ata_helper during the SAT check above. Attempt the NVMe
+        // passthrough discovery regardless of the SAT check result since SAT ATA passthrough is not reliable on all of
+        // these adapters.
+        bool checkRealtekNVMe = device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe;
 
         // Because we may find an NVMe over USB device, if we find one of these, perform a little more discovery...
         if ((device->drive_info.passThroughHacks.passthroughType >= NVME_PASSTHROUGH_JMICRON &&
@@ -4307,9 +4315,9 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                 }
                 else if (ret == SUCCESS && checkRealtekNVMe)
                 {
+                    set_Device_DriveType(device, NVME_DRIVE);
                     if (device->drive_info.passThroughHacks.passthroughType == NVME_PASSTHROUGH_REALTEK_BASIC)
                     {
-                        set_Device_DriveType(device, NVME_DRIVE);
                         device->drive_info.passThroughHacks.testUnitReadyAfterAnyCommandFailure = true;
                         device->drive_info.passThroughHacks.turfValue                           = 34;
                         device->drive_info.passThroughHacks.scsiHacks.readWrite.available       = true;
@@ -4346,6 +4354,12 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                         // Note: Get features works with a data transfer, but cannot get dword results
                         // TODO: Need to test for firmware update, format, and set features commands
                     }
+                    else
+                    {
+                        // The full 3-phase Realtek passthrough succeeded. Most of the SCSI hacks needed are already in
+                        // place from the inquiry data hacks for this bridge.
+                        device->drive_info.passThroughHacks.nvmePTHacks.maxTransferLength = UINT16_MAX;
+                    }
                 }
                 else if (ret != SUCCESS && (checkJMicronNVMe || checkRealtekNVMe))
                 {
@@ -4356,8 +4370,22 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                         device->drive_info.passThroughHacks.passthroughType = NVME_PASSTHROUGH_REALTEK_BASIC;
                         continue;
                     }
-                    device->drive_info.passThroughHacks.passthroughType = PASSTHROUGH_NONE;
-                    ret = scsiRet; // do not fail here since this should otherwise be treated as a SCSI drive
+                    if (checkRealtekNVMe)
+                    {
+                        // Not an NVMe drive after all, so this is likely a SATA drive behind the bridge. Restore the
+                        // SAT passthrough and fill in the ATA drive info the normal way.
+                        device->drive_info.passThroughHacks.passthroughType = ATA_PASSTHROUGH_SAT;
+                        if (SUCCESS != fill_In_ATA_Drive_Info(device))
+                        {
+                            set_Device_DriveType(device, SCSI_DRIVE);
+                        }
+                    }
+                    else
+                    {
+                        device->drive_info.passThroughHacks.passthroughType = PASSTHROUGH_NONE;
+                    }
+                    // do not fail here since this should otherwise be treated as a SCSI drive
+                    ret = scsiRet;
                 }
                 else if (ret == SUCCESS)
                 {

--- a/src/scsi_helper.c
+++ b/src/scsi_helper.c
@@ -3787,10 +3787,10 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                 safe_free_aligned(&deviceIdentification);
             }
             // One last thing...Need to do a SAT scan...
-            // NOTE: Skip the SAT compliance check for bridges that may have an NVMe drive behind them (e.g. Realtek
+            // NOTE: Skip the SAT compliance check for bridges that are known to be Realtek USB to NVMe adapters (e.g.
             // RTL9210). SAT ATA identify is not reliable on these adapters and can take a long time to time out, and
             // the NVMe passthrough discovery below handles these devices correctly.
-            if (checkForSAT && !device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe)
+            if (checkForSAT && !device->drive_info.passThroughHacks.ataPTHacks.knownRealtekUSB)
             {
                 if (SUCCESS != check_SAT_Compliance_And_Set_Drive_Type(device) && checkJMicronNVMe)
                 {
@@ -3821,12 +3821,12 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
                     }
                 }
             }
-            if (!device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe)
+            if (!device->drive_info.passThroughHacks.ataPTHacks.knownRealtekUSB)
             {
                 safe_free_aligned(&inq_buf);
                 return ret;
             }
-            // This bridge may have an NVMe drive behind it (e.g. Realtek RTL9210). Do not quit discovery early here so
+            // This bridge is a known Realtek USB to NVMe adapter (e.g. RTL9210). Do not quit discovery early here so
             // that the NVMe passthrough discovery below can run and correctly identify the drive in a fast scan.
         }
 
@@ -4259,23 +4259,22 @@ M_PARAM_RW(1) OPENSEA_TRANSPORT_API eReturnValues fill_In_Device_Info(tDevice* d
         eReturnValues satCheck = FAILURE;
         // if we haven't already, check the device for SAT support. Allow this to run on IDE interface since we'll just
         // issue a SAT identify in here to set things up...might reduce multiple commands later
-        // Skip this for bridges that are known to possibly be emulating an NVMe drive (e.g. Realtek RTL9210) since they
-        // do not reliably support SCSI-ATA passthrough. On some firmware revisions the SAT identify can take a very
-        // long time to fail with an internal adapter error, or never return at all. The NVMe passthrough identify is
-        // attempted below in that case instead.
+        // Skip this for bridges that are known to be Realtek USB to NVMe adapters (e.g. RTL9210) since they do not
+        // reliably support SCSI-ATA passthrough. On some firmware revisions the SAT identify can take a very long time
+        // to fail with an internal adapter error, or never return at all. The NVMe passthrough identify is attempted
+        // below in that case instead.
         if (checkForSAT && !satVPDPageRead && !satComplianceChecked && (get_Device_DriveType(device) != RAID_DRIVE) &&
             (get_Device_DriveType(device) != NVME_DRIVE) && get_Device_MediaType(device) != MEDIA_UNKNOWN &&
             device->drive_info.passThroughHacks.passthroughType < NVME_PASSTHROUGH_JMICRON &&
-            !device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe)
+            !device->drive_info.passThroughHacks.ataPTHacks.knownRealtekUSB)
         {
             satCheck = check_SAT_Compliance_And_Set_Drive_Type(device);
         }
 
-        // This flag is set for bridges that are known to possibly have an NVMe drive behind them (Realtek RTL9210),
-        // either by reported VID/PID or inquiry data, or by the ata_helper during the SAT check above. Attempt the NVMe
-        // passthrough discovery regardless of the SAT check result since SAT ATA passthrough is not reliable on all of
-        // these adapters.
-        bool checkRealtekNVMe = device->drive_info.passThroughHacks.ataPTHacks.possilbyEmulatedNVMe;
+        // This is only set for bridges that are known to be Realtek USB to NVMe/SATA adapters (RTL9210), either by
+        // reported VID/PID or by the ata_helper RTL9210 heuristic. Attempt the NVMe passthrough discovery regardless of
+        // the SAT check result since SAT ATA passthrough is not reliable on all of these adapters.
+        bool checkRealtekNVMe = device->drive_info.passThroughHacks.ataPTHacks.knownRealtekUSB;
 
         // Because we may find an NVMe over USB device, if we find one of these, perform a little more discovery...
         if ((device->drive_info.passThroughHacks.passthroughType >= NVME_PASSTHROUGH_JMICRON &&


### PR DESCRIPTION
Fixes discovery of NVMe drives behind Realtek RTL9210 USB bridges and
shows the real drive identity for drives behind USB bridges.

Related to Seagate/openSeaChest#109